### PR TITLE
Osquery: Update exported fields reference for osquery 5.14.1

### DIFF
--- a/docs/osquery/exported-fields-reference.asciidoc
+++ b/docs/osquery/exported-fields-reference.asciidoc
@@ -155,7 +155,7 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 
 *amperage* - keyword, number.long
 
-* _battery.amperage_ - The current amperage in/out of the battery in mA (positive means charging, negative means discharging)
+* _battery.amperage_ - The battery's current amperage in mA
 
 *anonymous* - keyword, number.long
 
@@ -749,10 +749,6 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 
 * _disk_events.checksum_ - UDIF Master checksum if available (CRC32)
 
-*chemistry* - keyword, text.text
-
-* _battery.chemistry_ - The battery chemistry type (eg. LiP). Some possible values are documented in https://learn.microsoft.com/en-us/windows/win32/power/battery-information-str.
-
 *child_pid* - keyword, number.long
 
 * _es_process_events.child_pid_ - Process ID of a child process in case of a fork event
@@ -1208,7 +1204,7 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 
 *current_capacity* - keyword, number.long
 
-* _battery.current_capacity_ - The battery's current capacity (level of charge) in mAh
+* _battery.current_capacity_ - The battery's current charged capacity in mAh
 
 *current_clock_speed* - keyword, number.long
 
@@ -2067,6 +2063,6532 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 
 *flags* - keyword
 
+* _device_partitions.flags_ - 
+* _dns_cache.flags_ - DNS record flags
+* _interface_details.flags_ - Flags (netdevice) for the device
+* _kernel_keys.flags_ - A set of flags describing the state of the key.
+* _mounts.flags_ - Mounted device flags
+* _pipes.flags_ - The flags indicating whether this pipe connection is a server or client end, and if the pipe for sending messages or bytes
+* _process_etw_events.flags_ - Process Flags
+* _routes.flags_ - Flags to describe route
+
+*folder_id* - keyword, text.text
+
+* _ycloud_instance_metadata.folder_id_ - Folder identifier for the VM
+
+*following* - keyword, text.text
+
+* _systemd_units.following_ - The name of another unit that this unit follows in state
+
+*force_logoff_when_expire* - keyword, number.long
+
+* _security_profile_info.force_logoff_when_expire_ - Determines whether SMB client sessions with the SMB server will be forcibly disconnected when the client's logon hours expire
+
+*forced* - keyword, number.long
+
+* _preferences.forced_ - 1 if the value is forced/managed, else 0
+
+*form_factor* - keyword, text.text
+
+* _memory_devices.form_factor_ - Implementation form factor for this memory device
+
+*format* - keyword, text.text
+
+* _cups_jobs.format_ - The format of the print job
+
+*forwarding_enabled* - keyword, number.long
+
+* _interface_ipv6.forwarding_enabled_ - Enable IP forwarding
+
+*fragment_path* - keyword, text.text
+
+* _systemd_units.fragment_path_ - The unit file path this unit was read from, if there is any
+
+*frame_backtrace* - keyword, text.text
+
+* _kernel_panics.frame_backtrace_ - Backtrace of the crashed module
+
+*free* - keyword, number.long
+
+* _virtual_memory_info.free_ - Total number of free pages.
+
+*free_space* - keyword, number.long
+
+* _logical_drives.free_space_ - The amount of free space, in bytes, of the drive (-1 on failure).
+
+*friendly_name* - keyword, text.text
+
+* _interface_addresses.friendly_name_ - The friendly display name of the interface.
+* _interface_details.friendly_name_ - The friendly display name of the interface.
+
+*from_webstore* - keyword, text.text
+
+* _chrome_extensions.from_webstore_ - True if this extension was installed from the web store
+
+*fs_id* - keyword, text.text
+
+* _quicklook_cache.fs_id_ - Quicklook file fs_id key
+
+*fsgid* - keyword
+
+* _process_events.fsgid_ - Filesystem group ID at process start
+* _process_file_events.fsgid_ - Filesystem group ID of the process using the file
+
+*fsuid* - keyword
+
+* _apparmor_events.fsuid_ - Filesystem user ID
+* _process_events.fsuid_ - Filesystem user ID at process start
+* _process_file_events.fsuid_ - Filesystem user ID of the process using the file
+
+*gateway* - keyword, text.text
+
+* _docker_container_networks.gateway_ - Gateway
+* _docker_networks.gateway_ - Network gateway
+* _routes.gateway_ - Route gateway
+
+*gid* - keyword
+
+* _asl.gid_ - GID that sent the log message (set by the server).
+* _bpf_process_events.gid_ - Group ID
+* _bpf_socket_events.gid_ - Group ID
+* _device_file.gid_ - Owning group ID
+* _docker_container_processes.gid_ - Group ID
+* _es_process_events.gid_ - Group ID of the process
+* _file.gid_ - Owning group ID
+* _file_events.gid_ - Owning group ID
+* _groups.gid_ - Unsigned int64 group ID
+* _kernel_keys.gid_ - The group ID of the key.
+* _package_bom.gid_ - Expected group of file or directory
+* _process_events.gid_ - Group ID at process start
+* _process_file_events.gid_ - The gid of the process performing the action
+* _processes.gid_ - Unsigned group ID
+* _seccomp_events.gid_ - Group ID of the user who started the analyzed process
+* _user_groups.gid_ - Group ID
+* _users.gid_ - Group ID (unsigned)
+
+*gid_signed* - keyword, number.long
+
+* _groups.gid_signed_ - A signed int64 version of gid
+* _users.gid_signed_ - Default group ID as int64 signed (Apple)
+
+*git_commit* - keyword, text.text
+
+* _docker_version.git_commit_ - Docker build git commit
+
+*global_seq_num* - keyword, number.long
+
+* _es_process_events.global_seq_num_ - Global sequence number
+* _es_process_file_events.global_seq_num_ - Global sequence number
+
+*global_state* - keyword, number.long
+
+* _alf.global_state_ - 1 If the firewall is enabled with exceptions, 2 if the firewall is configured to block all incoming connections, else 0
+
+*go_version* - keyword, text.text
+
+* _docker_version.go_version_ - Go version
+
+*gpgcheck* - keyword, text.text
+
+* _yum_sources.gpgcheck_ - Whether packages are GPG checked
+
+*gpgkey* - keyword, text.text
+
+* _yum_sources.gpgkey_ - URL to GPG key
+
+*grace_period* - keyword, number.long
+
+* _screenlock.grace_period_ - The amount of time in seconds the screen must be asleep or the screensaver on before a password is required on-wake. 0 = immediately; -1 = no password is required on-wake
+
+*group_sid* - keyword, text.text
+
+* _groups.group_sid_ - Unique group ID
+
+*grouping* - keyword, text.text
+
+* _windows_firewall_rules.grouping_ - Group to which an individual rule belongs
+
+*groupname* - keyword, text.text
+
+* _groups.groupname_ - Canonical local group name
+* _launchd.groupname_ - Run this daemon or agent as this group
+* _rpm_package_files.groupname_ - File default groupname from info DB
+* _suid_bin.groupname_ - Binary owner group
+
+*guest* - keyword, number.long
+
+* _cpu_time.guest_ - Time spent running a virtual CPU for a guest OS under the control of the Linux kernel
+
+*guest_nice* - keyword, number.long
+
+* _cpu_time.guest_nice_ - Time spent running a niced guest 
+
+*handle* - keyword, text.text
+
+* _memory_array_mapped_addresses.handle_ - Handle, or instance number, associated with the structure
+* _memory_arrays.handle_ - Handle, or instance number, associated with the array
+* _memory_device_mapped_addresses.handle_ - Handle, or instance number, associated with the structure
+* _memory_devices.handle_ - Handle, or instance number, associated with the structure in SMBIOS
+* _memory_error_info.handle_ - Handle, or instance number, associated with the structure
+* _oem_strings.handle_ - Handle, or instance number, associated with the Type 11 structure
+* _smbios_tables.handle_ - Table entry handle
+
+*handle_count* - keyword, number.long
+
+* _processes.handle_count_ - Total number of handles that the process has open. This number is the sum of the handles currently opened by each thread in the process.
+
+*handler* - keyword, text.text
+
+* _app_schemes.handler_ - Application label for the handler
+
+*hard_limit* - keyword, text.text
+
+* _ulimit_info.hard_limit_ - Maximum limit value
+
+*hard_links* - keyword, number.long
+
+* _device_file.hard_links_ - Number of hard links
+* _file.hard_links_ - Number of hard links
+
+*hardware_model* - keyword, text.text
+
+* _disk_info.hardware_model_ - Hard drive model.
+* _system_info.hardware_model_ - Hardware model
+
+*hardware_serial* - keyword, text.text
+
+* _system_info.hardware_serial_ - Device serial number
+
+*hardware_vendor* - keyword, text.text
+
+* _system_info.hardware_vendor_ - Hardware vendor
+
+*hardware_version* - keyword, text.text
+
+* _system_info.hardware_version_ - Hardware version
+
+*has_expired* - keyword, number.long
+
+* _curl_certificate.has_expired_ - 1 if the certificate has expired, 0 otherwise
+
+*hash* - keyword, text.text
+
+* _prefetch.hash_ - Prefetch CRC hash.
+
+*hash_alg* - keyword, text.text
+
+* _shadow.hash_alg_ - Password hashing algorithm
+
+*hash_resources* - keyword, number.long
+
+* _signature.hash_resources_ - Set to 1 to also hash resources, or 0 otherwise. Default is 1
+
+*hashed* - keyword, number.long
+
+* _file_events.hashed_ - 1 if the file was hashed, 0 if not, -1 if hashing failed
+
+*header* - keyword, text.text
+
+* _sudoers.header_ - Symbol for given rule
+
+*header_pid* - keyword, number.long
+
+* _process_etw_events.header_pid_ - Process ID of the process reporting the event
+
+*header_size* - keyword, number.long
+
+* _smbios_tables.header_size_ - Header size in bytes
+
+*health* - keyword, text.text
+
+* _battery.health_ - One of the following: "Good" describes a well-performing battery, "Fair" describes a functional battery with limited capacity, or "Poor" describes a battery that's not capable of providing power
+
+*hidden* - keyword, number.long
+
+* _scheduled_tasks.hidden_ - Whether or not the task is visible in the UI
+* _smc_keys.hidden_ - 1 if this key is normally hidden, otherwise 0
+
+*history_file* - keyword, text.text
+
+* _shell_history.history_file_ - Path to the .*_history for this user
+
+*hit_count* - keyword, text.text
+
+* _quicklook_cache.hit_count_ - Number of cache hits on thumbnail
+
+*home_directory* - keyword, text.text
+
+* _logon_sessions.home_directory_ - The home directory for the logon session.
+
+*home_directory_drive* - keyword, text.text
+
+* _logon_sessions.home_directory_drive_ - The drive location of the home directory of the logon session.
+
+*homepage* - keyword, text.text
+
+* _npm_packages.homepage_ - Package supplied homepage
+
+*hop_limit* - keyword, number.long
+
+* _interface_ipv6.hop_limit_ - Current Hop Limit
+
+*hopcount* - keyword, number.long
+
+* _routes.hopcount_ - Max hops expected
+
+*host* - keyword, text.text
+
+* _asl.host_ - Sender's address (set by the server).
+* _last.host_ - Entry hostname
+* _logged_in_users.host_ - Remote hostname
+* _preferences.host_ - 'current' or 'any' host, where 'current' takes precedence
+* _syslog_events.host_ - Hostname configured for syslog
+
+*host_ip* - keyword, text.text
+
+* _docker_container_ports.host_ip_ - Host IP address on which public port is listening
+
+*host_port* - keyword, number.long
+
+* _docker_container_ports.host_port_ - Host port
+
+*hostname* - keyword, text.text
+
+* _curl_certificate.hostname_ - Hostname to CURL (domain[:port], e.g. osquery.io)
+* _system_info.hostname_ - Network hostname including domain
+* _ycloud_instance_metadata.hostname_ - Hostname of the VM
+
+*hostnames* - keyword, text.text
+
+* _etc_hosts.hostnames_ - Raw hosts mapping
+
+*hotfix_id* - keyword, text.text
+
+* _patches.hotfix_id_ - The KB ID of the patch.
+
+*hour* - keyword, text.text
+
+* _crontab.hour_ - The hour of the day for the job
+* _time.hour_ - Current hour in UTC
+
+*hours* - keyword, number.long
+
+* _uptime.hours_ - Hours of uptime
+
+*hresult* - keyword, number.long
+
+* _windows_update_history.hresult_ - HRESULT value that is returned from the operation on an update
+
+*http_proxy* - keyword, text.text
+
+* _docker_info.http_proxy_ - HTTP proxy
+
+*https_proxy* - keyword, text.text
+
+* _docker_info.https_proxy_ - HTTPS proxy
+
+*hwaddr* - keyword, text.text
+
+* _lxd_networks.hwaddr_ - Hardware address for this network
+
+*iam_arn* - keyword, text.text
+
+* _ec2_instance_metadata.iam_arn_ - If there is an IAM role associated with the instance, contains instance profile ARN
+
+*ibrs_support_enabled* - keyword, number.long
+
+* _kva_speculative_info.ibrs_support_enabled_ - Windows uses IBRS.
+
+*ibytes* - keyword, number.long
+
+* _interface_details.ibytes_ - Input bytes
+
+*icmp_types_codes* - keyword, text.text
+
+* _windows_firewall_rules.icmp_types_codes_ - ICMP types and codes for the rule
+
+*icon_mode* - keyword, number.long
+
+* _quicklook_cache.icon_mode_ - Thumbnail icon mode
+
+*id* - keyword, text.text
+
+* _disk_info.id_ - The unique identifier of the drive on the system.
+* _dns_resolvers.id_ - Address type index or order
+* _docker_container_envs.id_ - Container ID
+* _docker_container_fs_changes.id_ - Container ID
+* _docker_container_labels.id_ - Container ID
+* _docker_container_mounts.id_ - Container ID
+* _docker_container_networks.id_ - Container ID
+* _docker_container_ports.id_ - Container ID
+* _docker_container_processes.id_ - Container ID
+* _docker_container_stats.id_ - Container ID
+* _docker_containers.id_ - Container ID
+* _docker_image_history.id_ - Image ID
+* _docker_image_labels.id_ - Image ID
+* _docker_image_layers.id_ - Image ID
+* _docker_images.id_ - Image ID
+* _docker_info.id_ - Docker system ID
+* _docker_network_labels.id_ - Network ID
+* _docker_networks.id_ - Network ID
+* _iokit_devicetree.id_ - IOKit internal registry ID
+* _iokit_registry.id_ - IOKit internal registry ID
+* _lxd_images.id_ - Image ID
+* _systemd_units.id_ - Unique unit identifier
+
+*identifier* - keyword, text.text
+
+* _browser_plugins.identifier_ - Plugin identifier
+* _chrome_extension_content_scripts.identifier_ - Extension identifier
+* _chrome_extensions.identifier_ - Extension identifier, computed from its manifest. Empty in case of error.
+* _crashes.identifier_ - Identifier of the crashed process
+* _firefox_addons.identifier_ - Addon identifier
+* _safari_extensions.identifier_ - Extension identifier
+* _signature.identifier_ - The signing identifier sealed into the signature
+* _system_extensions.identifier_ - Identifier name
+* _xprotect_meta.identifier_ - Browser plugin or extension identifier
+
+*identifying_number* - keyword, text.text
+
+* _programs.identifying_number_ - Product identification such as a serial number on software, or a die number on a hardware chip.
+
+*identity* - keyword, text.text
+
+* _xprotect_entries.identity_ - XProtect identity (SHA1) of content
+
+*idle* - keyword, number.long
+
+* _cpu_time.idle_ - Time spent in the idle task
+
+*idrops* - keyword, number.long
+
+* _interface_details.idrops_ - Input drops
+
+*idx* - keyword, number.long
+
+* _kernel_extensions.idx_ - Extension load tag or index
+
+*ierrors* - keyword, number.long
+
+* _interface_details.ierrors_ - Input errors
+
+*image* - keyword, text.text
+
+* _docker_containers.image_ - Docker image (name) used to launch this container
+* _drivers.image_ - Path to driver image file
+
+*image_id* - keyword, text.text
+
+* _docker_containers.image_id_ - Docker image ID
+
+*images* - keyword, number.long
+
+* _docker_info.images_ - Number of images
+
+*inactive* - keyword, number.long
+
+* _memory_info.inactive_ - The total amount of buffer or page cache memory, in bytes, that are free and available
+* _shadow.inactive_ - Number of days after password expires until account is blocked
+* _virtual_memory_info.inactive_ - Total number of inactive pages.
+
+*inetd_compatibility* - keyword, text.text
+
+* _launchd.inetd_compatibility_ - Run this daemon or agent as it was launched from inetd
+
+*inf* - keyword, text.text
+
+* _drivers.inf_ - Associated inf file
+
+*info* - keyword, text.text
+
+* _apparmor_events.info_ - Additional information
+
+*info_access* - keyword, text.text
+
+* _curl_certificate.info_access_ - Authority Information Access
+
+*info_string* - keyword, text.text
+
+* _apps.info_string_ - Info properties CFBundleGetInfoString label
+
+*inherited_from* - keyword, text.text
+
+* _ntfs_acl_permissions.inherited_from_ - The inheritance policy of the ACE.
+
+*iniface* - keyword, text.text
+
+* _iptables.iniface_ - Input interface for the rule.
+
+*iniface_mask* - keyword, text.text
+
+* _iptables.iniface_mask_ - Input interface mask for the rule.
+
+*inode* - keyword, number.long
+
+* _device_file.inode_ - Filesystem inode number
+* _device_hash.inode_ - Filesystem inode number
+* _file.inode_ - Filesystem inode number
+* _file_events.inode_ - Filesystem inode number
+* _process_memory_map.inode_ - Mapped path inode, 0 means uninitialized (BSS)
+* _process_open_pipes.inode_ - Pipe inode number
+* _quicklook_cache.inode_ - Parsed file ID (inode) from fs_id
+
+*inodes* - keyword, number.long
+
+* _device_partitions.inodes_ - Number of meta nodes
+* _mounts.inodes_ - Mounted device used inodes
+
+*inodes_free* - keyword, number.long
+
+* _mounts.inodes_free_ - Mounted device free inodes
+
+*inodes_total* - keyword, number.long
+
+* _lxd_storage_pools.inodes_total_ - Total number of inodes available in this storage pool
+
+*inodes_used* - keyword, number.long
+
+* _lxd_storage_pools.inodes_used_ - Number of inodes used
+
+*input_eax* - keyword, text.text
+
+* _cpuid.input_eax_ - Value of EAX used
+
+*install_date* - keyword
+
+* _os_version.install_date_ - The install date of the OS.
+* _patches.install_date_ - Indicates when the patch was installed. Lack of a value does not indicate that the patch was not installed.
+* _programs.install_date_ - Date that this product was installed on the system. 
+* _shared_resources.install_date_ - Indicates when the object was installed. Lack of a value does not indicate that the object is not installed.
+
+*install_location* - keyword, text.text
+
+* _programs.install_location_ - The installation location directory of the product.
+
+*install_source* - keyword, text.text
+
+* _programs.install_source_ - The installation source of the product.
+
+*install_time* - keyword
+
+* _appcompat_shims.install_time_ - Install time of the SDB
+* _chrome_extensions.install_time_ - Extension install time, in its original Webkit format
+* _package_receipts.install_time_ - Timestamp of install time
+* _rpm_packages.install_time_ - When the package was installed
+
+*install_timestamp* - keyword, number.long
+
+* _chrome_extensions.install_timestamp_ - Extension install time, converted to unix time
+
+*installed_at* - keyword, number.long
+
+* _vscode_extensions.installed_at_ - Installed Timestamp
+
+*installed_by* - keyword, text.text
+
+* _patches.installed_by_ - The system context in which the patch as installed.
+
+*installed_on* - keyword, text.text
+
+* _patches.installed_on_ - The date when the patch was installed.
+
+*installer_name* - keyword, text.text
+
+* _package_receipts.installer_name_ - Name of installer process
+
+*instance_id* - keyword, text.text
+
+* _ec2_instance_metadata.instance_id_ - EC2 instance ID
+* _ec2_instance_tags.instance_id_ - EC2 instance ID
+* _osquery_info.instance_id_ - Unique, long-lived ID per instance of osquery
+* _ycloud_instance_metadata.instance_id_ - Unique identifier for the VM
+
+*instance_identifier* - keyword, text.text
+
+* _hvci_status.instance_identifier_ - The instance ID of Device Guard.
+
+*instance_type* - keyword, text.text
+
+* _ec2_instance_metadata.instance_type_ - EC2 instance type
+
+*instances* - keyword, number.long
+
+* _pipes.instances_ - Number of instances of the named pipe
+
+*interface* - keyword, text.text
+
+* _arp_cache.interface_ - Interface of the network for the MAC
+* _interface_addresses.interface_ - Interface name
+* _interface_details.interface_ - Interface name
+* _interface_ipv6.interface_ - Interface name
+* _routes.interface_ - Route local interface
+* _wifi_status.interface_ - Name of the interface
+* _wifi_survey.interface_ - Name of the interface
+
+*interleave_data_depth* - keyword, number.long
+
+* _memory_device_mapped_addresses.interleave_data_depth_ - The max number of consecutive rows from memory device that are accessed in a single interleave transfer; 0 indicates device is non-interleave
+
+*interleave_position* - keyword, number.long
+
+* _memory_device_mapped_addresses.interleave_position_ - The position of the device in a interleave, i.e. 0 indicates non-interleave, 1 indicates 1st interleave, 2 indicates 2nd interleave, etc.
+
+*internal* - keyword, number.long
+
+* _osquery_registry.internal_ - 1 If the plugin is internal else 0
+
+*internet_settings* - keyword, text.text
+
+* _windows_security_center.internet_settings_ - The health of the Internet Settings
+
+*internet_sharing* - keyword, number.long
+
+* _sharing_preferences.internet_sharing_ - 1 If internet sharing is enabled else 0
+
+*interval* - keyword, number.long
+
+* _docker_container_stats.interval_ - Difference between read and preread in nano-seconds
+* _osquery_schedule.interval_ - The interval in seconds to run this query, not an exact interval
+
+*iowait* - keyword, number.long
+
+* _cpu_time.iowait_ - Time spent waiting for I/O to complete
+
+*ip* - keyword, text.text
+
+* _seccomp_events.ip_ - Instruction pointer value
+
+*ip_address* - keyword, text.text
+
+* _docker_container_networks.ip_address_ - IP address
+
+*ip_prefix_len* - keyword, number.long
+
+* _docker_container_networks.ip_prefix_len_ - IP subnet prefix length
+
+*ipackets* - keyword, number.long
+
+* _interface_details.ipackets_ - Input packets
+
+*ipc_namespace* - keyword, text.text
+
+* _docker_containers.ipc_namespace_ - IPC namespace
+* _process_namespaces.ipc_namespace_ - ipc namespace inode
+
+*ipv4_address* - keyword, text.text
+
+* _lxd_networks.ipv4_address_ - IPv4 address
+
+*ipv4_forwarding* - keyword, number.long
+
+* _docker_info.ipv4_forwarding_ - 1 if IPv4 forwarding is enabled. 0 otherwise
+
+*ipv4_internet* - keyword, number.long
+
+* _connectivity.ipv4_internet_ - True if any interface is connected to the Internet via IPv4
+
+*ipv4_local_network* - keyword, number.long
+
+* _connectivity.ipv4_local_network_ - True if any interface is connected to a routed network via IPv4
+
+*ipv4_no_traffic* - keyword, number.long
+
+* _connectivity.ipv4_no_traffic_ - True if any interface is connected via IPv4, but has seen no traffic
+
+*ipv4_subnet* - keyword, number.long
+
+* _connectivity.ipv4_subnet_ - True if any interface is connected to the local subnet via IPv4
+
+*ipv6_address* - keyword, text.text
+
+* _docker_container_networks.ipv6_address_ - IPv6 address
+* _lxd_networks.ipv6_address_ - IPv6 address
+
+*ipv6_gateway* - keyword, text.text
+
+* _docker_container_networks.ipv6_gateway_ - IPv6 gateway
+
+*ipv6_internet* - keyword, number.long
+
+* _connectivity.ipv6_internet_ - True if any interface is connected to the Internet via IPv6
+
+*ipv6_local_network* - keyword, number.long
+
+* _connectivity.ipv6_local_network_ - True if any interface is connected to a routed network via IPv6
+
+*ipv6_no_traffic* - keyword, number.long
+
+* _connectivity.ipv6_no_traffic_ - True if any interface is connected via IPv6, but has seen no traffic
+
+*ipv6_prefix_len* - keyword, number.long
+
+* _docker_container_networks.ipv6_prefix_len_ - IPv6 subnet prefix length
+
+*ipv6_subnet* - keyword, number.long
+
+* _connectivity.ipv6_subnet_ - True if any interface is connected to the local subnet via IPv6
+
+*irq* - keyword, number.long
+
+* _cpu_time.irq_ - Time spent servicing interrupts
+
+*is_active* - keyword, number.long
+
+* _running_apps.is_active_ - (DEPRECATED)
+
+*is_hidden* - keyword, number.long
+
+* _groups.is_hidden_ - IsHidden attribute set in OpenDirectory
+* _users.is_hidden_ - IsHidden attribute set in OpenDirectory
+
+*iso_8601* - keyword, text.text
+
+* _time.iso_8601_ - Current time (ISO format) in UTC
+
+*issuer* - keyword, text.text
+
+* _certificates.issuer_ - Certificate issuer distinguished name (deprecated, use issuer2)
+
+*issuer2* - keyword, text.text
+
+* _certificates.issuer2_ - Certificate issuer distinguished name
+
+*issuer_alternative_names* - keyword, text.text
+
+* _curl_certificate.issuer_alternative_names_ - Issuer Alternative Name
+
+*issuer_common_name* - keyword, text.text
+
+* _curl_certificate.issuer_common_name_ - Issuer common name
+
+*issuer_name* - keyword, text.text
+
+* _authenticode.issuer_name_ - The certificate issuer name
+
+*issuer_organization* - keyword, text.text
+
+* _curl_certificate.issuer_organization_ - Issuer organization
+
+*issuer_organization_unit* - keyword, text.text
+
+* _curl_certificate.issuer_organization_unit_ - Issuer organization unit
+
+*job_id* - keyword, number.long
+
+* _systemd_units.job_id_ - Next queued job id
+
+*job_path* - keyword, text.text
+
+* _systemd_units.job_path_ - The object path for the job
+
+*job_type* - keyword, text.text
+
+* _systemd_units.job_type_ - Job type
+
+*json_cmdline* - keyword, text.text
+
+* _bpf_process_events.json_cmdline_ - Command line arguments, in JSON format
+
+*keep_alive* - keyword, text.text
+
+* _launchd.keep_alive_ - Should the process be restarted if killed
+
+*kernel_extensions* - keyword, number.long
+
+* _secureboot.kernel_extensions_ - (Apple Silicon) Allow user management of kernel extensions from identified developers (1 if allowed)
+
+*kernel_memory* - keyword, number.long
+
+* _docker_info.kernel_memory_ - 1 if kernel memory limit support is enabled. 0 otherwise
+
+*kernel_version* - keyword, text.text
+
+* _docker_info.kernel_version_ - Kernel version
+* _docker_version.kernel_version_ - Kernel version
+* _kernel_panics.kernel_version_ - Version of the system kernel
+
+*key* - keyword, text.text
+
+* _authorized_keys.key_ - Key encoded as base64
+* _azure_instance_tags.key_ - The tag key
+* _chrome_extensions.key_ - The extension key, from the manifest file
+* _docker_container_envs.key_ - Environment variable name
+* _docker_container_labels.key_ - Label key
+* _docker_image_labels.key_ - Label key
+* _docker_network_labels.key_ - Label key
+* _docker_volume_labels.key_ - Label key
+* _ec2_instance_tags.key_ - Tag key
+* _extended_attributes.key_ - Name of the value generated from the extended attribute
+* _known_hosts.key_ - parsed authorized keys line
+* _launchd_overrides.key_ - Name of the override key
+* _lxd_instance_config.key_ - Configuration parameter name
+* _lxd_instance_devices.key_ - Device info param name
+* _mdls.key_ - Name of the metadata key
+* _plist.key_ - Preference top-level key
+* _power_sensors.key_ - The SMC key on macOS
+* _preferences.key_ - Preference top-level key
+* _process_envs.key_ - Environment variable name
+* _registry.key_ - Name of the key to search for
+* _selinux_settings.key_ - Key or class name.
+* _smc_keys.key_ - 4-character key
+* _temperature_sensors.key_ - The SMC key on macOS
+
+*key_algorithm* - keyword, text.text
+
+* _certificates.key_algorithm_ - Key algorithm used
+
+*key_file* - keyword, text.text
+
+* _authorized_keys.key_file_ - Path to the authorized_keys file
+* _known_hosts.key_file_ - Path to known_hosts file
+
+*key_strength* - keyword, text.text
+
+* _certificates.key_strength_ - Key size used for RSA/DSA, or curve name
+
+*key_type* - keyword, text.text
+
+* _user_ssh_keys.key_type_ - The type of the private key. One of [rsa, dsa, dh, ec, hmac, cmac], or the empty string.
+
+*key_usage* - keyword, text.text
+
+* _certificates.key_usage_ - Certificate key usage and extended key usage
+* _curl_certificate.key_usage_ - Usage of key in certificate
+
+*keychain_path* - keyword, text.text
+
+* _keychain_acls.keychain_path_ - The path of the keychain
+
+*keyword* - keyword, text.text
+
+* _portage_keywords.keyword_ - The keyword applied to the package
+
+*keywords* - keyword, text.text
+
+* _windows_eventlog.keywords_ - A bitmask of the keywords defined in the event
+* _windows_events.keywords_ - A bitmask of the keywords defined in the event
+
+*kva_shadow_enabled* - keyword, number.long
+
+* _kva_speculative_info.kva_shadow_enabled_ - Kernel Virtual Address shadowing is enabled.
+
+*kva_shadow_inv_pcid* - keyword, number.long
+
+* _kva_speculative_info.kva_shadow_inv_pcid_ - Kernel VA INVPCID is enabled.
+
+*kva_shadow_pcid* - keyword, number.long
+
+* _kva_speculative_info.kva_shadow_pcid_ - Kernel VA PCID flushing optimization is enabled.
+
+*kva_shadow_user_global* - keyword, number.long
+
+* _kva_speculative_info.kva_shadow_user_global_ - User pages are marked as global.
+
+*label* - keyword, text.text
+
+* _apparmor_events.label_ - AppArmor label
+* _augeas.label_ - The label of the configuration item
+* _authorization_mechanisms.label_ - Label of the authorization right
+* _authorizations.label_ - Item name, usually in reverse domain format
+* _block_devices.label_ - Block device label string
+* _device_partitions.label_ - 
+* _keychain_acls.label_ - An optional label tag that may be included with the keychain entry
+* _keychain_items.label_ - Generic item name
+* _launchd.label_ - Daemon or agent service name
+* _launchd_overrides.label_ - Daemon or agent service name
+* _quicklook_cache.label_ - Parsed version 'gen' field
+* _sandboxes.label_ - UTI-format bundle or label ID
+
+*language* - keyword, text.text
+
+* _programs.language_ - The language of the product.
+
+*last_change* - keyword, number.long
+
+* _interface_details.last_change_ - Time of last device modification (optional)
+* _shadow.last_change_ - Date of last password change (starting from UNIX epoch date)
+
+*last_connected* - keyword, number.long
+
+* _wifi_networks.last_connected_ - Last time this network was connected to as a unix_time
+
+*last_executed* - keyword, number.long
+
+* _osquery_schedule.last_executed_ - UNIX time stamp in seconds of the last completed execution
+
+*last_execution_time* - keyword, number.long
+
+* _background_activities_moderator.last_execution_time_ - Most recent time application was executed.
+* _userassist.last_execution_time_ - Most recent time application was executed.
+
+*last_hit_date* - keyword, number.long
+
+* _quicklook_cache.last_hit_date_ - Apple date format for last thumbnail cache hit
+
+*last_loaded* - keyword, text.text
+
+* _kernel_panics.last_loaded_ - Last loaded module before panic
+
+*last_memory* - keyword, number.long
+
+* _osquery_schedule.last_memory_ - Resident memory in bytes left allocated after collecting results of the latest execution
+
+*last_opened_time* - keyword
+
+* _apps.last_opened_time_ - The time that the app was last used
+* _office_mru.last_opened_time_ - Most recent opened time file was opened
+
+*last_run_code* - keyword, text.text
+
+* _scheduled_tasks.last_run_code_ - Exit status code of the last task run
+
+*last_run_message* - keyword, text.text
+
+* _scheduled_tasks.last_run_message_ - Exit status message of the last task run
+
+*last_run_time* - keyword, number.long
+
+* _prefetch.last_run_time_ - Most recent time application was run.
+* _scheduled_tasks.last_run_time_ - Timestamp the task last ran
+
+*last_system_time* - keyword, number.long
+
+* _osquery_schedule.last_system_time_ - System time in milliseconds of the latest execution
+
+*last_unloaded* - keyword, text.text
+
+* _kernel_panics.last_unloaded_ - Last unloaded module before panic
+
+*last_used_at* - keyword, text.text
+
+* _lxd_images.last_used_at_ - ISO time for the most recent use of this image in terms of container spawn
+
+*last_user_time* - keyword, number.long
+
+* _osquery_schedule.last_user_time_ - User time in milliseconds of the latest execution
+
+*last_wall_time_ms* - keyword, number.long
+
+* _osquery_schedule.last_wall_time_ms_ - Wall time in milliseconds of the latest execution
+
+*launch_type* - keyword, text.text
+
+* _xprotect_entries.launch_type_ - Launch services content type
+
+*layer_id* - keyword, text.text
+
+* _docker_image_layers.layer_id_ - Layer ID
+
+*layer_order* - keyword, number.long
+
+* _docker_image_layers.layer_order_ - Layer Order (1 = base layer)
+
+*level* - keyword
+
+* _asl.level_ - Log level number.  See levels in asl.h.
+* _unified_log.level_ - the severity level of the entry
+* _windows_eventlog.level_ - Severity level associated with the event
+* _windows_events.level_ - The severity level associated with the event
+
+*license* - keyword, text.text
+
+* _chocolatey_packages.license_ - License under which package is launched
+* _npm_packages.license_ - License under which package is launched
+* _python_packages.license_ - License under which package is launched
+
+*link_speed* - keyword, number.long
+
+* _interface_details.link_speed_ - Interface speed in Mb/s
+
+*linked_against* - keyword, text.text
+
+* _kernel_extensions.linked_against_ - Indexes of extensions this extension is linked against
+
+*load_state* - keyword, text.text
+
+* _systemd_units.load_state_ - Reflects whether the unit definition was properly loaded
+
+*local_address* - keyword, text.text
+
+* _bpf_socket_events.local_address_ - Local address associated with socket
+* _process_open_sockets.local_address_ - Socket local address
+* _socket_events.local_address_ - Local address associated with socket
+
+*local_addresses* - keyword, text.text
+
+* _windows_firewall_rules.local_addresses_ - Local addresses for the rule
+
+*local_hostname* - keyword, text.text
+
+* _ec2_instance_metadata.local_hostname_ - Private IPv4 DNS hostname of the first interface of this instance
+* _system_info.local_hostname_ - Local hostname (optional)
+
+*local_ipv4* - keyword, text.text
+
+* _ec2_instance_metadata.local_ipv4_ - Private IPv4 address of the first interface of this instance
+
+*local_port* - keyword, number.long
+
+* _bpf_socket_events.local_port_ - Local network protocol port number
+* _process_open_sockets.local_port_ - Socket local port
+* _socket_events.local_port_ - Local network protocol port number
+
+*local_ports* - keyword, text.text
+
+* _windows_firewall_rules.local_ports_ - Local ports for the rule
+
+*local_timezone* - keyword, text.text
+
+* _time.local_timezone_ - Current local timezone in of the system
+
+*location* - keyword, text.text
+
+* _azure_instance_metadata.location_ - Azure Region the VM is running in
+* _firefox_addons.location_ - Global, profile location
+* _memory_arrays.location_ - Physical location of the memory array
+* _package_receipts.location_ - Optional relative install path on volume
+
+*lock* - keyword, text.text
+
+* _chassis_info.lock_ - If TRUE, the frame is equipped with a lock.
+
+*lock_status* - keyword, number.long
+
+* _bitlocker_info.lock_status_ - The accessibility status of the drive from Windows.
+
+*locked* - keyword, number.long
+
+* _shared_memory.locked_ - 1 if segment is locked else 0
+
+*lockout_bad_count* - keyword, number.long
+
+* _security_profile_info.lockout_bad_count_ - Number of failed logon attempts after which a user account MUST be locked out
+
+*log_file_disk_quota_mb* - keyword, number.long
+
+* _carbon_black_info.log_file_disk_quota_mb_ - Event file disk quota in MB
+
+*log_file_disk_quota_percentage* - keyword, number.long
+
+* _carbon_black_info.log_file_disk_quota_percentage_ - Event file disk quota in a percentage
+
+*logging_driver* - keyword, text.text
+
+* _docker_info.logging_driver_ - Logging driver
+
+*logging_enabled* - keyword, number.long
+
+* _alf.logging_enabled_ - 1 If logging mode is enabled else 0
+
+*logging_option* - keyword, number.long
+
+* _alf.logging_option_ - Firewall logging option
+
+*logical_processors* - keyword, number.long
+
+* _cpu_info.logical_processors_ - The number of logical processors of the CPU.
+
+*logon_domain* - keyword, text.text
+
+* _logon_sessions.logon_domain_ - The name of the domain used to authenticate the owner of the logon session.
+
+*logon_id* - keyword, number.long
+
+* _logon_sessions.logon_id_ - A locally unique identifier (LUID) that identifies a logon session.
+
+*logon_script* - keyword, text.text
+
+* _logon_sessions.logon_script_ - The script used for logging on.
+
+*logon_server* - keyword, text.text
+
+* _logon_sessions.logon_server_ - The name of the server used to authenticate the owner of the logon session.
+
+*logon_sid* - keyword, text.text
+
+* _logon_sessions.logon_sid_ - The user's security identifier (SID).
+
+*logon_time* - keyword, number.long
+
+* _logon_sessions.logon_time_ - The time the session owner logged on.
+
+*logon_to_change_password* - keyword, number.long
+
+* _security_profile_info.logon_to_change_password_ - Determines if logon session is required to change the password
+
+*logon_type* - keyword, text.text
+
+* _logon_sessions.logon_type_ - The logon method.
+
+*lsa_anonymous_name_lookup* - keyword, number.long
+
+* _security_profile_info.lsa_anonymous_name_lookup_ - Determines if an anonymous user is allowed to query the local LSA policy
+
+*mac* - keyword, text.text
+
+* _arp_cache.mac_ - MAC address of broadcasted address
+* _ec2_instance_metadata.mac_ - MAC address for the first network interface of this EC2 instance
+* _interface_details.mac_ - MAC of interface (optional)
+
+*mac_address* - keyword, text.text
+
+* _docker_container_networks.mac_address_ - MAC address
+
+*machine_name* - keyword, text.text
+
+* _windows_crashes.machine_name_ - Name of the machine where the crash happened
+
+*magic_db_files* - keyword, text.text
+
+* _magic.magic_db_files_ - Colon(:) separated list of files where the magic db file can be found. By default one of the following is used: /usr/share/file/magic/magic, /usr/share/misc/magic or /usr/share/misc/magic.mgc
+
+*main* - keyword, number.long
+
+* _connected_displays.main_ - If the display is the main display.
+
+*maintainer* - keyword, text.text
+
+* _apt_sources.maintainer_ - Repository maintainer
+* _deb_packages.maintainer_ - Package maintainer
+
+*major* - keyword, number.long
+
+* _os_version.major_ - Major release version
+
+*major_version* - keyword, number.long
+
+* _windows_crashes.major_version_ - Windows major version of the machine
+
+*managed* - keyword, number.long
+
+* _lxd_networks.managed_ - 1 if network created by LXD, 0 otherwise
+
+*mandatory_label* - keyword, text.text
+
+* _process_etw_events.mandatory_label_ - Primary token mandatory label sid - Present only on ProcessStart events
+
+*manifest_hash* - keyword, text.text
+
+* _chrome_extensions.manifest_hash_ - The SHA256 hash of the manifest.json file
+
+*manifest_json* - keyword, text.text
+
+* _chrome_extensions.manifest_json_ - The manifest file of the extension
+
+*manual* - keyword, number.long
+
+* _managed_policies.manual_ - 1 if policy was loaded manually, otherwise 0
+
+*manufacture_date* - keyword, number.long
+
+* _battery.manufacture_date_ - The date the battery was manufactured UNIX Epoch
+
+*manufactured_week* - keyword, number.long
+
+* _connected_displays.manufactured_week_ - The manufacture week of the display. This field is 0 if not supported
+
+*manufactured_year* - keyword, number.long
+
+* _connected_displays.manufactured_year_ - The manufacture year of the display. This field is 0 if not supported
+
+*manufacturer* - keyword, text.text
+
+* _battery.manufacturer_ - The battery manufacturer's name
+* _chassis_info.manufacturer_ - The manufacturer of the chassis.
+* _cpu_info.manufacturer_ - The manufacturer of the CPU.
+* _disk_info.manufacturer_ - The manufacturer of the disk.
+* _drivers.manufacturer_ - Device manufacturer
+* _interface_details.manufacturer_ - Name of the network adapter's manufacturer.
+* _memory_devices.manufacturer_ - Manufacturer ID string
+* _video_info.manufacturer_ - The manufacturer of the gpu.
+
+*manufacturer_id* - keyword, number.long
+
+* _tpm_info.manufacturer_id_ - TPM manufacturers ID
+
+*manufacturer_name* - keyword, text.text
+
+* _tpm_info.manufacturer_name_ - TPM manufacturers name
+
+*manufacturer_version* - keyword, text.text
+
+* _tpm_info.manufacturer_version_ - TPM version
+
+*mask* - keyword, text.text
+
+* _interface_addresses.mask_ - Interface netmask
+* _portage_keywords.mask_ - If the package is masked
+
+*match* - keyword, text.text
+
+* _chrome_extension_content_scripts.match_ - The pattern that the script is matched against
+* _iptables.match_ - Matching rule that applies.
+
+*matches* - keyword, text.text
+
+* _yara.matches_ - List of YARA matches
+* _yara_events.matches_ - List of YARA matches
+
+*max* - keyword, number.long
+
+* _fan_speed_sensors.max_ - Maximum speed
+* _shadow.max_ - Maximum number of days between password changes
+
+*max_capacity* - keyword, number.long
+
+* _battery.max_capacity_ - The battery's actual capacity when it is fully charged in mAh
+* _memory_arrays.max_capacity_ - Maximum capacity of array in gigabytes
+
+*max_clock_speed* - keyword, number.long
+
+* _cpu_info.max_clock_speed_ - The maximum possible frequency of the CPU.
+
+*max_instances* - keyword, number.long
+
+* _pipes.max_instances_ - The maximum number of instances creatable for this pipe
+
+*max_results* - keyword, number.long
+
+* _windows_search.max_results_ - Maximum number of results returned by windows api, set to -1 for unlimited
+
+*max_rows* - keyword, number.long
+
+* _unified_log.max_rows_ - the max number of rows returned (defaults to 100)
+
+*max_speed* - keyword, number.long
+
+* _memory_devices.max_speed_ - Max speed of memory device in megatransfers per second (MT/s)
+
+*max_voltage* - keyword, number.long
+
+* _memory_devices.max_voltage_ - Maximum operating voltage of device in millivolts
+
+*maximum_allowed* - keyword, number.long
+
+* _shared_resources.maximum_allowed_ - Limit on the maximum number of users allowed to use this resource concurrently. The value is only valid if the AllowMaximum property is set to FALSE.
+
+*maximum_password_age* - keyword, number.long
+
+* _security_profile_info.maximum_password_age_ - Determines the maximum number of days that a password can be used before the client requires the user to change it
+
+*md5* - keyword, text.text
+
+* _acpi_tables.md5_ - MD5 hash of table content
+* _device_hash.md5_ - MD5 hash of provided inode data
+* _file_events.md5_ - The MD5 of the file after change
+* _hash.md5_ - MD5 hash of provided filesystem data
+* _smbios_tables.md5_ - MD5 hash of table entry
+
+*md_device_name* - keyword, text.text
+
+* _md_drives.md_device_name_ - md device name
+
+*mdm_managed* - keyword, number.long
+
+* _system_extensions.mdm_managed_ - 1 if managed by MDM system extension payload configuration, 0 otherwise
+
+*mdm_operations* - keyword, number.long
+
+* _secureboot.mdm_operations_ - (Apple Silicon) Allow remote (MDM) management of kernel extensions and automatic software updates (1 if allowed)
+
+*mechanism* - keyword, text.text
+
+* _authorization_mechanisms.mechanism_ - Name of the mechanism that will be called
+
+*media_name* - keyword, text.text
+
+* _disk_events.media_name_ - Disk event media name string
+
+*mem* - keyword, number.double
+
+* _docker_container_processes.mem_ - Memory utilization as percentage
+
+*member_config_description* - keyword, text.text
+
+* _lxd_cluster.member_config_description_ - Config description
+
+*member_config_entity* - keyword, text.text
+
+* _lxd_cluster.member_config_entity_ - Type of configuration parameter for this node
+
+*member_config_key* - keyword, text.text
+
+* _lxd_cluster.member_config_key_ - Config key
+
+*member_config_name* - keyword, text.text
+
+* _lxd_cluster.member_config_name_ - Name of configuration parameter
+
+*member_config_value* - keyword, text.text
+
+* _lxd_cluster.member_config_value_ - Config value
+
+*memory* - keyword, number.long
+
+* _docker_info.memory_ - Total memory
+
+*memory_array_error_address* - keyword, text.text
+
+* _memory_error_info.memory_array_error_address_ - 32 bit physical address of the error based on the addressing of the bus to which the memory array is connected
+
+*memory_array_handle* - keyword, text.text
+
+* _memory_array_mapped_addresses.memory_array_handle_ - Handle of the memory array associated with this structure
+
+*memory_array_mapped_address_handle* - keyword, text.text
+
+* _memory_device_mapped_addresses.memory_array_mapped_address_handle_ - Handle of the memory array mapped address to which this device range is mapped to
+
+*memory_available* - keyword, number.long
+
+* _memory_info.memory_available_ - The amount of physical RAM, in bytes, available for starting new applications, without swapping
+
+*memory_cached* - keyword, number.long
+
+* _docker_container_stats.memory_cached_ - Memory cached
+
+*memory_device_handle* - keyword, text.text
+
+* _memory_device_mapped_addresses.memory_device_handle_ - Handle of the memory device structure associated with this structure
+
+*memory_error_correction* - keyword, text.text
+
+* _memory_arrays.memory_error_correction_ - Primary hardware error correction or detection method supported
+
+*memory_error_info_handle* - keyword, text.text
+
+* _memory_arrays.memory_error_info_handle_ - Handle, or instance number, associated with any error that was detected for the array
+
+*memory_free* - keyword, number.long
+
+* _memory_info.memory_free_ - The amount of physical RAM, in bytes, left unused by the system
+
+*memory_limit* - keyword, number.long
+
+* _docker_container_stats.memory_limit_ - Memory limit
+* _docker_info.memory_limit_ - 1 if memory limit support is enabled. 0 otherwise
+
+*memory_max_usage* - keyword, number.long
+
+* _docker_container_stats.memory_max_usage_ - Memory maximum usage
+
+*memory_total* - keyword, number.long
+
+* _memory_info.memory_total_ - Total amount of physical RAM, in bytes
+
+*memory_type* - keyword, text.text
+
+* _memory_devices.memory_type_ - Type of memory used
+
+*memory_type_details* - keyword, text.text
+
+* _memory_devices.memory_type_details_ - Additional details for memory device
+
+*memory_usage* - keyword, number.long
+
+* _docker_container_stats.memory_usage_ - Memory usage
+
+*message* - keyword, text.text
+
+* _apparmor_events.message_ - Raw audit message
+* _asl.message_ - Message text.
+* _lxd_cluster_members.message_ - Message from the node (Online/Offline)
+* _selinux_events.message_ - Message
+* _syslog_events.message_ - The syslog message
+* _unified_log.message_ - composed message
+* _user_events.message_ - Message from the event
+
+*metadata_endpoint* - keyword, text.text
+
+* _ycloud_instance_metadata.metadata_endpoint_ - Endpoint used to fetch VM metadata
+
+*method* - keyword, text.text
+
+* _curl.method_ - The HTTP method for the request
+
+*metric* - keyword, number.long
+
+* _interface_details.metric_ - Metric based on the speed of the interface
+* _routes.metric_ - Cost of route. Lowest is preferred
+
+*metric_name* - keyword, text.text
+
+* _prometheus_metrics.metric_name_ - Name of collected Prometheus metric
+
+*metric_value* - keyword, number.double
+
+* _prometheus_metrics.metric_value_ - Value of collected Prometheus metric
+
+*mft_entry* - keyword, number.long
+
+* _shellbags.mft_entry_ - Directory master file table entry.
+
+*mft_sequence* - keyword, number.long
+
+* _shellbags.mft_sequence_ - Directory master file table sequence.
+
+*mime_encoding* - keyword, text.text
+
+* _magic.mime_encoding_ - MIME encoding data from libmagic
+
+*mime_type* - keyword, text.text
+
+* _magic.mime_type_ - MIME type data from libmagic
+
+*min* - keyword, number.long
+
+* _fan_speed_sensors.min_ - Minimum speed
+* _shadow.min_ - Minimal number of days between password changes
+
+*min_api_version* - keyword, text.text
+
+* _docker_version.min_api_version_ - Minimum API version supported
+
+*min_version* - keyword, text.text
+
+* _xprotect_meta.min_version_ - The minimum allowed plugin version.
+
+*min_voltage* - keyword, number.long
+
+* _memory_devices.min_voltage_ - Minimum operating voltage of device in millivolts
+
+*minimum_password_age* - keyword, number.long
+
+* _security_profile_info.minimum_password_age_ - Determines the minimum number of days that a password must be used before the user can change it
+
+*minimum_password_length* - keyword, number.long
+
+* _security_profile_info.minimum_password_length_ - Determines the least number of characters that can make up a password for a user account
+
+*minimum_system_version* - keyword, text.text
+
+* _apps.minimum_system_version_ - Minimum version of macOS required for the app to run
+
+*minor* - keyword, number.long
+
+* _os_version.minor_ - Minor release version
+
+*minor_version* - keyword, number.long
+
+* _windows_crashes.minor_version_ - Windows minor version of the machine
+
+*minute* - keyword, text.text
+
+* _crontab.minute_ - The exact minute for the job
+
+*minutes* - keyword, number.long
+
+* _time.minutes_ - Current minutes in UTC
+* _uptime.minutes_ - Minutes of uptime
+
+*minutes_to_full_charge* - keyword, number.long
+
+* _battery.minutes_to_full_charge_ - The number of minutes until the battery is fully charged. This value is -1 if this time is still being calculated
+
+*minutes_until_empty* - keyword, number.long
+
+* _battery.minutes_until_empty_ - The number of minutes until the battery is fully depleted. This value is -1 if this time is still being calculated
+
+*mirror* - keyword, number.long
+
+* _connected_displays.mirror_ - If the display is mirrored or not. This field is 1 if mirrored and 0 if not mirrored.
+
+*mirrorlist* - keyword, text.text
+
+* _yum_sources.mirrorlist_ - Mirrorlist URL
+
+*mnt_namespace* - keyword, text.text
+
+* _docker_containers.mnt_namespace_ - Mount namespace
+* _process_namespaces.mnt_namespace_ - mnt namespace inode
+
+*mode* - keyword, text.text
+
+* _apparmor_profiles.mode_ - How the policy is applied.
+* _device_file.mode_ - Permission bits
+* _docker_container_mounts.mode_ - Mount options (rw, ro)
+* _file.mode_ - Permission bits
+* _file_events.mode_ - Permission bits
+* _package_bom.mode_ - Expected permissions
+* _process_events.mode_ - File mode permissions
+* _process_open_pipes.mode_ - Pipe open mode (r/w)
+* _rpm_package_files.mode_ - File permissions mode from info DB
+* _wifi_status.mode_ - The current operating mode for the Wi-Fi interface
+
+*model* - keyword, text.text
+
+* _battery.model_ - The battery's model number
+* _block_devices.model_ - Block device model string identifier
+* _chassis_info.model_ - The model of the chassis.
+* _cpu_info.model_ - The model of the CPU.
+* _hardware_events.model_ - Hardware device model
+* _pci_devices.model_ - PCI Device model
+* _usb_devices.model_ - USB Device model string
+* _video_info.model_ - The model of the gpu.
+
+*model_id* - keyword, text.text
+
+* _hardware_events.model_id_ - Hex encoded Hardware model identifier
+* _pci_devices.model_id_ - Hex encoded PCI Device model identifier
+* _usb_devices.model_id_ - Hex encoded USB Device model identifier
+
+*modified* - keyword, text.text
+
+* _authorizations.modified_ - Label top-level key
+* _keychain_items.modified_ - Date of last modification
+
+*modified_time* - keyword, number.long
+
+* _package_bom.modified_time_ - Timestamp the file was installed
+* _shellbags.modified_time_ - Directory Modified time.
+* _shimcache.modified_time_ - File Modified time.
+
+*module* - keyword, text.text
+
+* _windows_crashes.module_ - Path of the crashed module within the process
+
+*module_backtrace* - keyword, text.text
+
+* _kernel_panics.module_backtrace_ - Modules appearing in the crashed module's backtrace
+
+*module_path* - keyword, text.text
+
+* _services.module_path_ - Path to ServiceDll
+
+*month* - keyword, text.text
+
+* _crontab.month_ - The month of the year for the job
+* _time.month_ - Current month in UTC
+
+*mount_namespace_id* - keyword, text.text
+
+* _deb_packages.mount_namespace_id_ - Mount namespace id
+* _file.mount_namespace_id_ - Mount namespace id
+* _hash.mount_namespace_id_ - Mount namespace id
+* _npm_packages.mount_namespace_id_ - Mount namespace id
+* _os_version.mount_namespace_id_ - Mount namespace id
+* _rpm_packages.mount_namespace_id_ - Mount namespace id
+
+*mount_point* - keyword, text.text
+
+* _docker_volumes.mount_point_ - Mount point
+
+*mountable* - keyword, number.long
+
+* _disk_events.mountable_ - 1 if mountable, 0 if not
+
+*mtime* - keyword
+
+* _device_file.mtime_ - Last modification time
+* _file.mtime_ - Last modification time
+* _file_events.mtime_ - Last modification time
+* _gatekeeper_approved_apps.mtime_ - Last modification time
+* _process_events.mtime_ - File modification in UNIX time
+* _quicklook_cache.mtime_ - Parsed version date field
+* _registry.mtime_ - timestamp of the most recent registry write
+
+*mtu* - keyword, number.long
+
+* _interface_details.mtu_ - Network MTU
+* _lxd_networks.mtu_ - MTU size
+* _routes.mtu_ - Maximum Transmission Unit for the route
+
+*name* - keyword, text.text
+
+* _acpi_tables.name_ - ACPI table name
+* _ad_config.name_ - The macOS-specific configuration name
+* _apparmor_events.name_ - Process name
+* _apparmor_profiles.name_ - Policy name.
+* _apps.name_ - Name of the Name.app folder
+* _apt_sources.name_ - Repository name
+* _autoexec.name_ - Name of the program
+* _azure_instance_metadata.name_ - Name of the VM
+* _block_devices.name_ - Block device name
+* _browser_plugins.name_ - Plugin display name
+* _chocolatey_packages.name_ - Package display name
+* _chrome_extensions.name_ - Extension display name
+* _connected_displays.name_ - The name of the display.
+* _cups_destinations.name_ - Name of the printer
+* _deb_packages.name_ - Package name
+* _disk_encryption.name_ - Disk name
+* _disk_events.name_ - Disk event name
+* _disk_info.name_ - The label of the disk object.
+* _dns_cache.name_ - DNS record name
+* _docker_container_mounts.name_ - Optional mount name
+* _docker_container_networks.name_ - Network name
+* _docker_container_processes.name_ - The process path or shorthand argv[0]
+* _docker_container_stats.name_ - Container name
+* _docker_containers.name_ - Container name
+* _docker_info.name_ - Name of the docker host
+* _docker_networks.name_ - Network name
+* _docker_volume_labels.name_ - Volume name
+* _docker_volumes.name_ - Volume name
+* _etc_protocols.name_ - Protocol name
+* _etc_services.name_ - Service name
+* _fan_speed_sensors.name_ - Fan name
+* _firefox_addons.name_ - Addon display name
+* _homebrew_packages.name_ - Package name
+* _ie_extensions.name_ - Extension display name
+* _iokit_devicetree.name_ - Device node name
+* _iokit_registry.name_ - Default name of the node
+* _kernel_extensions.name_ - Extension label
+* _kernel_modules.name_ - Module name
+* _kernel_panics.name_ - Process name corresponding to crashed thread
+* _launchd.name_ - File name of plist (used by launchd)
+* _lxd_certificates.name_ - Name of the certificate
+* _lxd_instance_config.name_ - Instance name
+* _lxd_instance_devices.name_ - Instance name
+* _lxd_instances.name_ - Instance name
+* _lxd_networks.name_ - Name of the network
+* _lxd_storage_pools.name_ - Name of the storage pool
+* _managed_policies.name_ - Policy key name
+* _md_personalities.name_ - Name of personality supported by kernel
+* _memory_map.name_ - Region name
+* _npm_packages.name_ - Package display name
+* _ntdomains.name_ - The label by which the object is known.
+* _nvram.name_ - Variable name
+* _os_version.name_ - Distribution or product name
+* _osquery_events.name_ - Event publisher or subscriber name
+* _osquery_extensions.name_ - Extension's name
+* _osquery_flags.name_ - Flag name
+* _osquery_packs.name_ - The given name for this query pack
+* _osquery_registry.name_ - Name of the plugin item
+* _osquery_schedule.name_ - The given name for this query
+* _package_install_history.name_ - Package display name
+* _physical_disk_performance.name_ - Name of the physical disk
+* _pipes.name_ - Name of the pipe
+* _power_sensors.name_ - Name of power source
+* _processes.name_ - The process path or shorthand argv[0]
+* _programs.name_ - Commonly used product name.
+* _python_packages.name_ - Package display name
+* _registry.name_ - Name of the registry value entry
+* _rpm_packages.name_ - RPM package name
+* _safari_extensions.name_ - Extension display name
+* _scheduled_tasks.name_ - Name of the scheduled task
+* _services.name_ - Service name
+* _shared_folders.name_ - The shared name of the folder as it appears to other users
+* _shared_resources.name_ - Alias given to a path set up as a share on a computer system running Windows.
+* _startup_items.name_ - Name of startup item
+* _system_controls.name_ - Full sysctl MIB name
+* _temperature_sensors.name_ - Name of temperature source
+* _vscode_extensions.name_ - Extension Name
+* _windows_firewall_rules.name_ - Friendly name of the rule
+* _windows_optional_features.name_ - Name of the feature
+* _windows_search.name_ - The name of the item
+* _windows_security_products.name_ - Name of product
+* _wmi_bios_info.name_ - Name of the Bios setting
+* _wmi_cli_event_consumers.name_ - Unique name of a consumer.
+* _wmi_event_filters.name_ - Unique identifier of an event filter.
+* _wmi_script_event_consumers.name_ - Unique identifier for the event consumer. 
+* _xprotect_entries.name_ - Description of XProtected malware
+* _xprotect_reports.name_ - Description of XProtected malware
+* _ycloud_instance_metadata.name_ - Name of the VM
+* _yum_sources.name_ - Repository name
+
+*name_constraints* - keyword, text.text
+
+* _curl_certificate.name_constraints_ - Name Constraints
+
+*namespace* - keyword, text.text
+
+* _apparmor_events.namespace_ - AppArmor namespace
+
+*native* - keyword, number.long
+
+* _browser_plugins.native_ - Plugin requires native execution
+
+*net_namespace* - keyword, text.text
+
+* _docker_containers.net_namespace_ - Network namespace
+* _listening_ports.net_namespace_ - The inode number of the network namespace
+* _process_namespaces.net_namespace_ - net namespace inode
+* _process_open_sockets.net_namespace_ - The inode number of the network namespace
+
+*netmask* - keyword, text.text
+
+* _dns_resolvers.netmask_ - Address (sortlist) netmask length
+* _routes.netmask_ - Netmask length
+
+*network_id* - keyword, text.text
+
+* _docker_container_networks.network_id_ - Network ID
+
+*network_name* - keyword, text.text
+
+* _wifi_networks.network_name_ - Name of the network
+* _wifi_status.network_name_ - Name of the network
+* _wifi_survey.network_name_ - Name of the network
+
+*network_rx_bytes* - keyword, number.long
+
+* _docker_container_stats.network_rx_bytes_ - Total network bytes read
+
+*network_tx_bytes* - keyword, number.long
+
+* _docker_container_stats.network_tx_bytes_ - Total network bytes transmitted
+
+*new_administrator_name* - keyword, text.text
+
+* _security_profile_info.new_administrator_name_ - Determines the name of the Administrator account on the local computer
+
+*new_guest_name* - keyword, text.text
+
+* _security_profile_info.new_guest_name_ - Determines the name of the Guest account on the local computer
+
+*next_run_time* - keyword, number.long
+
+* _scheduled_tasks.next_run_time_ - Timestamp the task is scheduled to run next
+
+*nice* - keyword, number.long
+
+* _cpu_time.nice_ - Time spent in user mode with low priority (nice)
+* _docker_container_processes.nice_ - Process nice level (-20 to 20, default 0)
+* _processes.nice_ - Process nice level (-20 to 20, default 0)
+
+*no_proxy* - keyword, text.text
+
+* _docker_info.no_proxy_ - Comma-separated list of domain extensions proxy should not be used for
+
+*node* - keyword, text.text
+
+* _augeas.node_ - The node path of the configuration item
+
+*node_ref_number* - keyword, text.text
+
+* _ntfs_journal_events.node_ref_number_ - The ordinal that associates a journal record with a filename
+
+*noise* - keyword, number.long
+
+* _wifi_status.noise_ - The current noise measurement (dBm)
+* _wifi_survey.noise_ - The current noise measurement (dBm)
+
+*not_valid_after* - keyword, text.text
+
+* _certificates.not_valid_after_ - Certificate expiration data
+
+*not_valid_before* - keyword, text.text
+
+* _certificates.not_valid_before_ - Lower bound of valid date
+
+*nr_raid_disks* - keyword, number.long
+
+* _md_devices.nr_raid_disks_ - Number of partitions or disk devices to comprise the array
+
+*ntime* - keyword, text.text
+
+* _bpf_process_events.ntime_ - The nsecs uptime timestamp as obtained from BPF
+* _bpf_socket_events.ntime_ - The nsecs uptime timestamp as obtained from BPF
+
+*num_procs* - keyword, number.long
+
+* _docker_container_stats.num_procs_ - Number of processors
+
+*number* - keyword, number.long
+
+* _etc_protocols.number_ - Protocol number
+* _oem_strings.number_ - The string index of the structure
+* _smbios_tables.number_ - Table entry number
+
+*number_memory_devices* - keyword, number.long
+
+* _memory_arrays.number_memory_devices_ - Number of memory devices on array
+
+*number_of_cores* - keyword, text.text
+
+* _cpu_info.number_of_cores_ - The number of cores of the CPU.
+
+*number_of_efficiency_cores* - keyword, number.long
+
+* _cpu_info.number_of_efficiency_cores_ - The number of efficiency cores of the CPU. Only available on Apple Silicon
+
+*number_of_performance_cores* - keyword, number.long
+
+* _cpu_info.number_of_performance_cores_ - The number of performance cores of the CPU. Only available on Apple Silicon
+
+*object_name* - keyword, text.text
+
+* _winbaseobj.object_name_ - Object Name
+
+*object_path* - keyword, text.text
+
+* _systemd_units.object_path_ - The object path for this unit
+
+*object_type* - keyword, text.text
+
+* _winbaseobj.object_type_ - Object Type
+
+*obytes* - keyword, number.long
+
+* _interface_details.obytes_ - Output bytes
+
+*odrops* - keyword, number.long
+
+* _interface_details.odrops_ - Output drops
+
+*oerrors* - keyword, number.long
+
+* _interface_details.oerrors_ - Output errors
+
+*offer* - keyword, text.text
+
+* _azure_instance_metadata.offer_ - Offer information for the VM image (Azure image gallery VMs only)
+
+*offset* - keyword, number.long
+
+* _device_partitions.offset_ - 
+* _process_memory_map.offset_ - Offset into mapped path
+
+*oid* - keyword, text.text
+
+* _system_controls.oid_ - Control MIB
+
+*old_path* - keyword, text.text
+
+* _ntfs_journal_events.old_path_ - Old path (renames only)
+
+*on_demand* - keyword, text.text
+
+* _launchd.on_demand_ - Deprecated key, replaced by keep_alive
+
+*on_disk* - keyword, number.long
+
+* _processes.on_disk_ - The process path exists yes=1, no=0, unknown=-1
+
+*online* - keyword, number.long
+
+* _connected_displays.online_ - The online status of the display. This field is 1 if the display is online and 0 if it is offline.
+
+*online_cpus* - keyword, number.long
+
+* _docker_container_stats.online_cpus_ - Online CPUs
+
+*oom_kill_disable* - keyword, number.long
+
+* _docker_info.oom_kill_disable_ - 1 if Out-of-memory kill is disabled. 0 otherwise
+
+*opackets* - keyword, number.long
+
+* _interface_details.opackets_ - Output packets
+
+*opaque_version* - keyword, text.text
+
+* _gatekeeper.opaque_version_ - Version of Gatekeeper's gkopaque.bundle
+
+*operation* - keyword, text.text
+
+* _apparmor_events.operation_ - Permission requested by the process
+* _process_file_events.operation_ - Operation type
+* _windows_update_history.operation_ - Operation on an update
+
+*option* - keyword, text.text
+
+* _ad_config.option_ - Canonical name of option
+* _ssh_configs.option_ - The option and value
+
+*option_name* - keyword, text.text
+
+* _cups_destinations.option_name_ - Option name
+
+*option_value* - keyword, text.text
+
+* _cups_destinations.option_value_ - Option value
+
+*optional* - keyword, number.long
+
+* _xprotect_entries.optional_ - Match any of the identities/patterns for this XProtect name
+
+*optional_permissions* - keyword, text.text
+
+* _chrome_extensions.optional_permissions_ - The permissions optionally required by the extensions
+
+*optional_permissions_json* - keyword, text.text
+
+* _chrome_extensions.optional_permissions_json_ - The JSON-encoded permissions optionally required by the extensions
+
+*options* - keyword, text.text
+
+* _authorized_keys.options_ - Optional list of login options
+* _dns_resolvers.options_ - Resolver options
+* _nfs_shares.options_ - Options string set on the export share
+
+*organization* - keyword, text.text
+
+* _curl_certificate.organization_ - Organization issued to
+
+*organization_unit* - keyword, text.text
+
+* _curl_certificate.organization_unit_ - Organization unit issued to
+
+*original_filename* - keyword, text.text
+
+* _file.original_filename_ - (Executable files only) Original filename
+
+*original_parent* - keyword, number.long
+
+* _es_process_events.original_parent_ - Original parent process ID in case of reparenting
+
+*original_program_name* - keyword, text.text
+
+* _authenticode.original_program_name_ - The original program name that the publisher has signed
+
+*os* - keyword, text.text
+
+* _docker_info.os_ - Operating system
+* _docker_version.os_ - Operating system
+* _lxd_images.os_ - OS on which image is based
+* _lxd_instances.os_ - The OS of this instance
+
+*os_type* - keyword, text.text
+
+* _azure_instance_metadata.os_type_ - Linux or Windows
+* _docker_info.os_type_ - Operating system type
+
+*os_version* - keyword, text.text
+
+* _kernel_panics.os_version_ - Version of the operating system
+
+*other* - keyword, text.text
+
+* _md_devices.other_ - Other information associated with array from /proc/mdstat
+
+*other_run_times* - keyword, text.text
+
+* _prefetch.other_run_times_ - Other execution times in prefetch file.
+
+*ouid* - keyword, number.long
+
+* _apparmor_events.ouid_ - Object owner's user ID
+
+*outiface* - keyword, text.text
+
+* _iptables.outiface_ - Output interface for the rule.
+
+*outiface_mask* - keyword, text.text
+
+* _iptables.outiface_mask_ - Output interface mask for the rule.
+
+*output_bit* - keyword, number.long
+
+* _cpuid.output_bit_ - Bit in register value for feature value
+
+*output_register* - keyword, text.text
+
+* _cpuid.output_register_ - Register used to for feature value
+
+*output_size* - keyword, number.long
+
+* _osquery_schedule.output_size_ - Cumulative total number of bytes generated by the resultant rows of the query
+
+*overflows* - keyword, text.text
+
+* _process_events.overflows_ - List of structures that overflowed
+
+*owned* - keyword, number.long
+
+* _tpm_info.owned_ - TPM is owned
+
+*owner* - keyword, text.text
+
+* _windows_search.owner_ - The owner of the item
+
+*owner_gid* - keyword, number.long
+
+* _process_events.owner_gid_ - File owner group ID
+
+*owner_uid* - keyword, number.long
+
+* _process_events.owner_uid_ - File owner user ID
+* _shared_memory.owner_uid_ - User ID of owning process
+
+*owner_uuid* - keyword, number.long
+
+* _osquery_registry.owner_uuid_ - Extension route UUID (0 for core)
+
+*package* - keyword, text.text
+
+* _portage_keywords.package_ - Package name
+* _portage_packages.package_ - Package name
+* _portage_use.package_ - Package name
+* _rpm_package_files.package_ - RPM package name
+
+*package_filename* - keyword, text.text
+
+* _package_receipts.package_filename_ - Filename of original .pkg file
+
+*package_group* - keyword, text.text
+
+* _rpm_packages.package_group_ - Package group
+
+*package_id* - keyword, text.text
+
+* _package_install_history.package_id_ - Label packageIdentifiers
+* _package_receipts.package_id_ - Package domain identifier
+
+*packets* - keyword, number.long
+
+* _iptables.packets_ - Number of matching packets for this rule.
+
+*packets_received* - keyword, number.long
+
+* _lxd_networks.packets_received_ - Number of packets received on this network
+
+*packets_sent* - keyword, number.long
+
+* _lxd_networks.packets_sent_ - Number of packets sent on this network
+
+*page_ins* - keyword, number.long
+
+* _virtual_memory_info.page_ins_ - The total number of requests for pages from a pager.
+
+*page_outs* - keyword, number.long
+
+* _virtual_memory_info.page_outs_ - Total number of pages paged out.
+
+*parent* - keyword
+
+* _apparmor_events.parent_ - Parent process PID
+* _block_devices.parent_ - Block device parent name
+* _bpf_process_events.parent_ - Parent process ID
+* _bpf_socket_events.parent_ - Parent process ID
+* _crashes.parent_ - Parent PID of the crashed process
+* _docker_container_processes.parent_ - Process parent's PID
+* _es_process_events.parent_ - Parent process ID
+* _es_process_file_events.parent_ - Parent process ID
+* _iokit_devicetree.parent_ - Parent device registry ID
+* _iokit_registry.parent_ - Parent registry ID
+* _process_events.parent_ - Process parent's PID, or -1 if cannot be determined.
+* _processes.parent_ - Process parent's PID
+
+*parent_process_sequence_number* - keyword, number.long
+
+* _process_etw_events.parent_process_sequence_number_ - Parent Process Sequence Number - Present only on ProcessStart events
+
+*parent_ref_number* - keyword, text.text
+
+* _ntfs_journal_events.parent_ref_number_ - The ordinal that associates a journal record with a filename's parent directory
+
+*part_number* - keyword, text.text
+
+* _memory_devices.part_number_ - Manufacturer specific serial number of memory device
+
+*partial* - keyword
+
+* _ntfs_journal_events.partial_ - Set to 1 if either path or old_path only contains the file or folder name
+* _process_file_events.partial_ - True if this is a partial event (i.e.: this process existed before we started osquery)
+
+*partition* - keyword, text.text
+
+* _device_file.partition_ - A partition number
+* _device_hash.partition_ - A partition number
+* _device_partitions.partition_ - A partition number or description
+
+*partition_row_position* - keyword, number.long
+
+* _memory_device_mapped_addresses.partition_row_position_ - Identifies the position of the referenced memory device in a row of the address partition
+
+*partition_width* - keyword, number.long
+
+* _memory_array_mapped_addresses.partition_width_ - Number of memory devices that form a single row of memory for the address partition of this structure
+
+*partitions* - keyword, number.long
+
+* _disk_info.partitions_ - Number of detected partitions on disk.
+
+*partner_fd* - keyword, number.long
+
+* _process_open_pipes.partner_fd_ - File descriptor of shared pipe at partner's end
+
+*partner_mode* - keyword, text.text
+
+* _process_open_pipes.partner_mode_ - Mode of shared pipe at partner's end
+
+*partner_pid* - keyword, number.long
+
+* _process_open_pipes.partner_pid_ - Process ID of partner process sharing a particular pipe
+
+*passpoint* - keyword, number.long
+
+* _wifi_networks.passpoint_ - 1 if Passpoint is supported, 0 otherwise
+
+*password_complexity* - keyword, number.long
+
+* _security_profile_info.password_complexity_ - Determines whether passwords must meet a series of strong-password guidelines
+
+*password_history_size* - keyword, number.long
+
+* _security_profile_info.password_history_size_ - Number of unique new passwords that must be associated with a user account before an old password can be reused
+
+*password_last_set_time* - keyword, number.double
+
+* _account_policy_data.password_last_set_time_ - The time the password was last changed
+
+*password_status* - keyword, text.text
+
+* _shadow.password_status_ - Password status
+
+*patch* - keyword, number.long
+
+* _os_version.patch_ - Optional patch release
+
+*path* - keyword, text.text
+
+* _alf_exceptions.path_ - Path to the executable that is excepted
+* _apparmor_profiles.path_ - Unique, aa-status compatible, policy identifier.
+* _appcompat_shims.path_ - This is the path to the SDB database.
+* _apps.path_ - Absolute and full Name.app path
+* _augeas.path_ - The path to the configuration file
+* _authenticode.path_ - Must provide a path or directory
+* _autoexec.path_ - Path to the executable
+* _background_activities_moderator.path_ - Application file path.
+* _bpf_process_events.path_ - Binary path
+* _bpf_socket_events.path_ - Path of executed file
+* _browser_plugins.path_ - Path to plugin bundle
+* _carves.path_ - The path of the requested carve
+* _certificates.path_ - Path to Keychain or PEM bundle
+* _chocolatey_packages.path_ - Path at which this package resides
+* _chrome_extension_content_scripts.path_ - Path to extension folder
+* _chrome_extensions.path_ - Path to extension folder
+* _crashes.path_ - Path to the crashed process
+* _crontab.path_ - File parsed
+* _device_file.path_ - A logical path within the device node
+* _disk_events.path_ - Path of the DMG file accessed
+* _docker_container_fs_changes.path_ - FIle or directory path relative to rootfs
+* _docker_containers.path_ - Container path
+* _es_process_events.path_ - Path of executed file
+* _es_process_file_events.path_ - Path of executed file
+* _extended_attributes.path_ - Absolute file path
+* _file.path_ - Absolute file path
+* _firefox_addons.path_ - Path to plugin bundle
+* _gatekeeper_approved_apps.path_ - Path of executable allowed to run
+* _hardware_events.path_ - Local device path assigned (optional)
+* _hash.path_ - Must provide a path or directory
+* _homebrew_packages.path_ - Package install path
+* _ie_extensions.path_ - Path to executable
+* _kernel_extensions.path_ - Optional path to extension bundle
+* _kernel_info.path_ - Kernel path
+* _kernel_panics.path_ - Location of log file
+* _keychain_acls.path_ - The path of the authorized application
+* _keychain_items.path_ - Path to keychain containing item
+* _launchd.path_ - Path to daemon or agent plist
+* _launchd_overrides.path_ - Path to daemon or agent plist
+* _listening_ports.path_ - Path for UNIX domain sockets
+* _magic.path_ - Absolute path to target file
+* _mdfind.path_ - Path of the file returned from spotlight
+* _mdls.path_ - Path of the file
+* _mounts.path_ - Mounted device path
+* _npm_packages.path_ - Path at which this module resides
+* _ntfs_acl_permissions.path_ - Path to the file or directory.
+* _ntfs_journal_events.path_ - Path
+* _office_mru.path_ - File path
+* _osquery_extensions.path_ - Path of the extension's Thrift connection or library path
+* _package_bom.path_ - Path of package bom
+* _package_receipts.path_ - Path of receipt plist
+* _plist.path_ - (required) read preferences from a plist
+* _prefetch.path_ - Prefetch file path.
+* _process_etw_events.path_ - Path of executed binary
+* _process_events.path_ - Path of executed file
+* _process_file_events.path_ - The path associated with the event
+* _process_memory_map.path_ - Path to mapped file or mapped type
+* _process_open_files.path_ - Filesystem path of descriptor
+* _process_open_sockets.path_ - For UNIX sockets (family=AF_UNIX), the domain path
+* _processes.path_ - Path to executed binary
+* _python_packages.path_ - Path at which this module resides
+* _quicklook_cache.path_ - Path of file
+* _registry.path_ - Full path to the value
+* _rpm_package_files.path_ - File path within the package
+* _safari_extensions.path_ - Path to extension XAR bundle
+* _sandboxes.path_ - Path to sandbox container directory
+* _scheduled_tasks.path_ - Path to the executable to be run
+* _services.path_ - Path to Service Executable
+* _shared_folders.path_ - Absolute path of shared folder on the local system
+* _shared_resources.path_ - Local path of the Windows share.
+* _shellbags.path_ - Directory name.
+* _shimcache.path_ - This is the path to the executed file.
+* _signature.path_ - Must provide a path or directory
+* _socket_events.path_ - Path of executed file
+* _startup_items.path_ - Path of startup item
+* _suid_bin.path_ - Binary path
+* _system_extensions.path_ - Original path of system extension
+* _user_events.path_ - Supplied path from event
+* _user_ssh_keys.path_ - Path to key file
+* _userassist.path_ - Application file path.
+* _vscode_extensions.path_ - Extension path
+* _windows_crashes.path_ - Path of the executable file for the crashed process
+* _windows_search.path_ - The full path of the item.
+* _yara.path_ - The path scanned
+
+*pci_class* - keyword, text.text
+
+* _pci_devices.pci_class_ - PCI Device class
+
+*pci_class_id* - keyword, text.text
+
+* _pci_devices.pci_class_id_ - PCI Device class ID in hex format
+
+*pci_slot* - keyword, text.text
+
+* _interface_details.pci_slot_ - PCI slot number
+* _pci_devices.pci_slot_ - PCI Device used slot
+
+*pci_subclass* - keyword, text.text
+
+* _pci_devices.pci_subclass_ - PCI Device subclass
+
+*pci_subclass_id* - keyword, text.text
+
+* _pci_devices.pci_subclass_id_ - PCI Device  subclass in hex format
+
+*pem* - keyword, text.text
+
+* _curl_certificate.pem_ - Certificate PEM format
+
+*percent_disk_read_time* - keyword, number.long
+
+* _physical_disk_performance.percent_disk_read_time_ - Percentage of elapsed time that the selected disk drive is busy servicing read requests
+
+*percent_disk_time* - keyword, number.long
+
+* _physical_disk_performance.percent_disk_time_ - Percentage of elapsed time that the selected disk drive is busy servicing read or write requests
+
+*percent_disk_write_time* - keyword, number.long
+
+* _physical_disk_performance.percent_disk_write_time_ - Percentage of elapsed time that the selected disk drive is busy servicing write requests
+
+*percent_idle_time* - keyword, number.long
+
+* _physical_disk_performance.percent_idle_time_ - Percentage of time during the sample interval that the disk was idle
+
+*percent_processor_time* - keyword, number.long
+
+* _processes.percent_processor_time_ - Returns elapsed time that all of the threads of this process used the processor to execute instructions in 100 nanoseconds ticks.
+
+*percent_remaining* - keyword, number.long
+
+* _battery.percent_remaining_ - The percentage of battery remaining before it is drained
+
+*percentage_encrypted* - keyword, number.long
+
+* _bitlocker_info.percentage_encrypted_ - The percentage of the drive that is encrypted.
+
+*perf_ctl* - keyword, number.long
+
+* _msr.perf_ctl_ - Performance setting for the processor.
+
+*perf_status* - keyword, number.long
+
+* _msr.perf_status_ - Performance status for the processor.
+
+*period* - keyword, text.text
+
+* _load_average.period_ - Period over which the average is calculated.
+
+*permanent* - keyword, text.text
+
+* _arp_cache.permanent_ - 1 for true, 0 for false
+
+*permissions* - keyword, text.text
+
+* _chrome_extensions.permissions_ - The permissions required by the extension
+* _kernel_keys.permissions_ - The key permissions, expressed as four hexadecimalbytes containing, from left to right, thepossessor, user, group, and other permissions.
+* _process_memory_map.permissions_ - r=read, w=write, x=execute, p=private (cow)
+* _shared_memory.permissions_ - Memory segment permissions
+* _suid_bin.permissions_ - Binary permissions
+
+*permissions_json* - keyword, text.text
+
+* _chrome_extensions.permissions_json_ - The JSON-encoded permissions required by the extension
+
+*persistent* - keyword, number.long
+
+* _chrome_extensions.persistent_ - 1 If extension is persistent across all tabs else 0
+
+*persistent_volume_id* - keyword, text.text
+
+* _bitlocker_info.persistent_volume_id_ - Persistent ID of the drive.
+
+*personal_hotspot* - keyword, number.long
+
+* _wifi_networks.personal_hotspot_ - 1 if this network is a personal hotspot, 0 otherwise
+
+*pgroup* - keyword, number.long
+
+* _docker_container_processes.pgroup_ - Process group
+* _processes.pgroup_ - Process group
+
+*physical_adapter* - keyword, number.long
+
+* _interface_details.physical_adapter_ - Indicates whether the adapter is a physical or a logical adapter.
+
+*physical_memory* - keyword, number.long
+
+* _system_info.physical_memory_ - Total physical memory in bytes
+
+*physical_presence_version* - keyword, text.text
+
+* _tpm_info.physical_presence_version_ - Version of the Physical Presence Interface
+
+*pid* - keyword, number.long
+
+* _apparmor_events.pid_ - Process ID
+* _asl.pid_ - Sending process ID encoded as a string.  Set automatically.
+* _bpf_process_events.pid_ - Process ID
+* _bpf_socket_events.pid_ - Process ID
+* _crashes.pid_ - Process (or thread) ID of the crashed process
+* _docker_container_processes.pid_ - Process ID
+* _docker_containers.pid_ - Identifier of the initial process
+* _es_process_events.pid_ - Process (or thread) ID
+* _es_process_file_events.pid_ - Process (or thread) ID
+* _last.pid_ - Process (or thread) ID
+* _listening_ports.pid_ - Process (or thread) ID
+* _logged_in_users.pid_ - Process (or thread) ID
+* _lxd_instances.pid_ - Instance's process ID
+* _osquery_info.pid_ - Process (or thread/handle) ID
+* _pipes.pid_ - Process ID of the process to which the pipe belongs
+* _process_envs.pid_ - Process (or thread) ID
+* _process_etw_events.pid_ - Process ID
+* _process_events.pid_ - Process (or thread) ID
+* _process_file_events.pid_ - Process ID
+* _process_memory_map.pid_ - Process (or thread) ID
+* _process_namespaces.pid_ - Process (or thread) ID
+* _process_open_files.pid_ - Process (or thread) ID
+* _process_open_pipes.pid_ - Process ID
+* _process_open_sockets.pid_ - Process (or thread) ID
+* _processes.pid_ - Process (or thread) ID
+* _running_apps.pid_ - The pid of the application
+* _seccomp_events.pid_ - Process ID
+* _services.pid_ - the Process ID of the service
+* _shared_memory.pid_ - Process ID to last use the segment
+* _socket_events.pid_ - Process (or thread) ID
+* _unified_log.pid_ - the pid of the process that made the entry
+* _user_events.pid_ - Process (or thread) ID
+* _windows_crashes.pid_ - Process ID of the crashed process
+* _windows_eventlog.pid_ - Process ID which emitted the event record
+
+*pid_namespace* - keyword, text.text
+
+* _docker_containers.pid_namespace_ - PID namespace
+* _process_namespaces.pid_namespace_ - pid namespace inode
+
+*pid_with_namespace* - keyword, number.long
+
+* _apt_sources.pid_with_namespace_ - Pids that contain a namespace
+* _authorized_keys.pid_with_namespace_ - Pids that contain a namespace
+* _crontab.pid_with_namespace_ - Pids that contain a namespace
+* _deb_packages.pid_with_namespace_ - Pids that contain a namespace
+* _dns_resolvers.pid_with_namespace_ - Pids that contain a namespace
+* _etc_hosts.pid_with_namespace_ - Pids that contain a namespace
+* _file.pid_with_namespace_ - Pids that contain a namespace
+* _groups.pid_with_namespace_ - Pids that contain a namespace
+* _hash.pid_with_namespace_ - Pids that contain a namespace
+* _npm_packages.pid_with_namespace_ - Pids that contain a namespace
+* _os_version.pid_with_namespace_ - Pids that contain a namespace
+* _python_packages.pid_with_namespace_ - Pids that contain a namespace
+* _rpm_packages.pid_with_namespace_ - Pids that contain a namespace
+* _suid_bin.pid_with_namespace_ - Pids that contain a namespace
+* _user_ssh_keys.pid_with_namespace_ - Pids that contain a namespace
+* _users.pid_with_namespace_ - Pids that contain a namespace
+* _yara.pid_with_namespace_ - Pids that contain a namespace
+* _yum_sources.pid_with_namespace_ - Pids that contain a namespace
+
+*pids* - keyword, number.long
+
+* _docker_container_stats.pids_ - Number of processes
+
+*pixels* - keyword, text.text
+
+* _connected_displays.pixels_ - The number of pixels of the display.
+
+*pk_hash* - keyword, text.text
+
+* _keychain_items.pk_hash_ - Hash of associated public key (SHA1 of subjectPublicKey, see RFC 8520 4.2.1.2)
+
+*placement_group_id* - keyword, text.text
+
+* _azure_instance_metadata.placement_group_id_ - Placement group for the VM scale set
+
+*platform* - keyword, text.text
+
+* _os_version.platform_ - OS Platform or ID
+* _osquery_packs.platform_ - Platforms this query is supported on
+
+*platform_binary* - keyword, number.long
+
+* _es_process_events.platform_binary_ - Indicates if the binary is Apple signed binary (1) or not (0)
+
+*platform_fault_domain* - keyword, text.text
+
+* _azure_instance_metadata.platform_fault_domain_ - Fault domain the VM is running in
+
+*platform_info* - keyword, number.long
+
+* _msr.platform_info_ - Platform information.
+
+*platform_like* - keyword, text.text
+
+* _os_version.platform_like_ - Closely related platforms
+
+*platform_mask* - keyword, number.long
+
+* _osquery_info.platform_mask_ - The osquery platform bitmask
+
+*platform_update_domain* - keyword, text.text
+
+* _azure_instance_metadata.platform_update_domain_ - Update domain the VM is running in
+
+*plugin* - keyword, text.text
+
+* _authorization_mechanisms.plugin_ - Authorization plugin name
+
+*pnp_device_id* - keyword, text.text
+
+* _disk_info.pnp_device_id_ - The unique identifier of the drive on the system.
+
+*point_to_point* - keyword, text.text
+
+* _interface_addresses.point_to_point_ - PtP address for the interface
+
+*policies* - keyword, text.text
+
+* _curl_certificate.policies_ - Certificate Policies
+
+*policy* - keyword, text.text
+
+* _iptables.policy_ - Policy that applies for this rule.
+
+*policy_constraints* - keyword, text.text
+
+* _curl_certificate.policy_constraints_ - Policy Constraints
+
+*policy_content* - keyword, text.text
+
+* _password_policy.policy_content_ - Policy content
+
+*policy_description* - keyword, text.text
+
+* _password_policy.policy_description_ - Policy description
+
+*policy_identifier* - keyword, text.text
+
+* _password_policy.policy_identifier_ - Policy Identifier
+
+*policy_mappings* - keyword, text.text
+
+* _curl_certificate.policy_mappings_ - Policy Mappings
+
+*port* - keyword, number.long
+
+* _docker_container_ports.port_ - Port inside the container
+* _etc_services.port_ - Service port number
+* _listening_ports.port_ - Transport layer port
+
+*possibly_hidden* - keyword, number.long
+
+* _wifi_networks.possibly_hidden_ - 1 if network is possibly a hidden network, 0 otherwise
+
+*ppid* - keyword, number.long
+
+* _process_etw_events.ppid_ - Parent Process ID
+* _process_file_events.ppid_ - Parent process ID
+
+*pre_cpu_kernelmode_usage* - keyword, number.long
+
+* _docker_container_stats.pre_cpu_kernelmode_usage_ - Last read CPU kernel mode usage
+
+*pre_cpu_total_usage* - keyword, number.long
+
+* _docker_container_stats.pre_cpu_total_usage_ - Last read total CPU usage
+
+*pre_cpu_usermode_usage* - keyword, number.long
+
+* _docker_container_stats.pre_cpu_usermode_usage_ - Last read CPU user mode usage
+
+*pre_online_cpus* - keyword, number.long
+
+* _docker_container_stats.pre_online_cpus_ - Last read online CPUs
+
+*pre_system_cpu_usage* - keyword, number.long
+
+* _docker_container_stats.pre_system_cpu_usage_ - Last read CPU system usage
+
+*predicate* - keyword, text.text
+
+* _unified_log.predicate_ - predicate to search (see `log help predicates`), note that this is merged into the predicate created from the column constraints
+
+*prefix* - keyword, text.text
+
+* _homebrew_packages.prefix_ - Homebrew install prefix
+
+*preread* - keyword, number.long
+
+* _docker_container_stats.preread_ - UNIX time when stats were last read
+
+*prerelease* - keyword, number.long
+
+* _vscode_extensions.prerelease_ - Pre release version
+
+*principal* - keyword, text.text
+
+* _ntfs_acl_permissions.principal_ - User or group to which the ACE applies.
+
+*printer_sharing* - keyword, number.long
+
+* _sharing_preferences.printer_sharing_ - 1 If printer sharing is enabled else 0
+
+*priority* - keyword, text.text
+
+* _deb_packages.priority_ - Package priority
+
+*privileged* - keyword, text.text
+
+* _authorization_mechanisms.privileged_ - If privileged it will run as root, else as an anonymous user
+* _docker_containers.privileged_ - Is the container privileged
+
+*probe_error* - keyword, number.long
+
+* _bpf_process_events.probe_error_ - Set to 1 if one or more buffers could not be captured
+* _bpf_socket_events.probe_error_ - Set to 1 if one or more buffers could not be captured
+
+*process* - keyword, text.text
+
+* _alf_explicit_auths.process_ - Process name explicitly allowed
+* _unified_log.process_ - the name of the process that made the entry
+
+*process_being_tapped* - keyword, number.long
+
+* _event_taps.process_being_tapped_ - The process ID of the target application
+
+*process_sequence_number* - keyword, number.long
+
+* _process_etw_events.process_sequence_number_ - Process Sequence Number - Present only on ProcessStart events
+
+*process_type* - keyword, text.text
+
+* _launchd.process_type_ - Key describes the intended purpose of the job
+
+*process_uptime* - keyword, number.long
+
+* _windows_crashes.process_uptime_ - Uptime of the process in seconds
+
+*processes* - keyword, number.long
+
+* _lxd_instances.processes_ - Number of processes running inside this instance
+
+*processing_time* - keyword, number.long
+
+* _cups_jobs.processing_time_ - How long the job took to process
+
+*processor_number* - keyword, number.long
+
+* _msr.processor_number_ - The processor number as reported in /proc/cpuinfo
+
+*processor_type* - keyword, text.text
+
+* _cpu_info.processor_type_ - The processor type, such as Central, Math, or Video.
+
+*product_id* - keyword, text.text
+
+* _connected_displays.product_id_ - The product ID of the display.
+
+*product_name* - keyword, text.text
+
+* _tpm_info.product_name_ - Product name of the TPM
+
+*product_version* - keyword, text.text
+
+* _file.product_version_ - File product version
+
+*profile* - keyword, text.text
+
+* _apparmor_events.profile_ - Apparmor profile name
+* _chrome_extensions.profile_ - The name of the Chrome profile that contains this extension
+
+*profile_domain* - keyword, number.long
+
+* _windows_firewall_rules.profile_domain_ - 1 if the rule profile type is domain
+
+*profile_path* - keyword, text.text
+
+* _chrome_extension_content_scripts.profile_path_ - The profile path
+* _chrome_extensions.profile_path_ - The profile path
+* _logon_sessions.profile_path_ - The home directory for the logon session.
+
+*profile_private* - keyword, number.long
+
+* _windows_firewall_rules.profile_private_ - 1 if the rule profile type is private
+
+*profile_public* - keyword, number.long
+
+* _windows_firewall_rules.profile_public_ - 1 if the rule profile type is public
+
+*program* - keyword, text.text
+
+* _launchd.program_ - Path to target program
+
+*program_arguments* - keyword, text.text
+
+* _launchd.program_arguments_ - Command line arguments passed to program
+
+*propagation* - keyword, text.text
+
+* _docker_container_mounts.propagation_ - Mount propagation
+
+*properties* - keyword, text.text
+
+* _windows_search.properties_ - Additional property values JSON
+
+*protected* - keyword, number.long
+
+* _app_schemes.protected_ - 1 if this handler is protected (reserved) by macOS, else 0
+
+*protection_disabled* - keyword, number.long
+
+* _carbon_black_info.protection_disabled_ - If the sensor is configured to report tamper events
+
+*protection_status* - keyword, number.long
+
+* _bitlocker_info.protection_status_ - The bitlocker protection status of the drive.
+
+*protection_type* - keyword, text.text
+
+* _processes.protection_type_ - The protection type of the process
+
+*protocol* - keyword
+
+* _bpf_socket_events.protocol_ - The network protocol ID
+* _etc_services.protocol_ - Transport protocol (TCP/UDP)
+* _iptables.protocol_ - Protocol number identification.
+* _listening_ports.protocol_ - Transport protocol (TCP/UDP)
+* _process_open_sockets.protocol_ - Transport protocol (TCP/UDP)
+* _socket_events.protocol_ - The network protocol ID
+* _usb_devices.protocol_ - USB Device protocol
+* _windows_firewall_rules.protocol_ - IP protocol of the rule
+
+*provider* - keyword, text.text
+
+* _drivers.provider_ - Driver provider
+
+*provider_guid* - keyword, text.text
+
+* _windows_eventlog.provider_guid_ - Provider guid of the event
+* _windows_events.provider_guid_ - Provider guid of the event
+
+*provider_name* - keyword, text.text
+
+* _windows_eventlog.provider_name_ - Provider name of the event
+* _windows_events.provider_name_ - Provider name of the event
+
+*pseudo* - keyword, number.long
+
+* _process_memory_map.pseudo_ - 1 If path is a pseudo path, else 0
+
+*public* - keyword, number.long
+
+* _lxd_images.public_ - Whether image is public (1) or not (0)
+
+*publisher* - keyword, text.text
+
+* _azure_instance_metadata.publisher_ - Publisher of the VM image
+* _osquery_events.publisher_ - Name of the associated publisher
+* _programs.publisher_ - Name of the product supplier.
+* _vscode_extensions.publisher_ - Publisher Name
+
+*publisher_id* - keyword, text.text
+
+* _vscode_extensions.publisher_id_ - Publisher ID
+
+*purgeable* - keyword, number.long
+
+* _virtual_memory_info.purgeable_ - Total number of purgeable pages.
+
+*purged* - keyword, number.long
+
+* _virtual_memory_info.purged_ - Total number of purged pages.
+
+*query* - keyword, text.text
+
+* _mdfind.query_ - The query that was run to find the file
+* _osquery_schedule.query_ - The exact query to run
+* _windows_search.query_ - Windows search query
+* _wmi_event_filters.query_ - Windows Management Instrumentation Query Language (WQL) event query that specifies the set of events for consumer notification, and the specific conditions for notification.
+
+*query_language* - keyword, text.text
+
+* _wmi_event_filters.query_language_ - Query language that the query is written in.
+
+*queue_directories* - keyword, text.text
+
+* _launchd.queue_directories_ - Similar to watch_paths but only with non-empty directories
+
+*raid_disks* - keyword, number.long
+
+* _md_devices.raid_disks_ - Number of configured RAID disks in array
+
+*raid_level* - keyword, number.long
+
+* _md_devices.raid_level_ - Current raid level of the array
+
+*rapl_energy_status* - keyword, number.long
+
+* _msr.rapl_energy_status_ - Run Time Average Power Limiting energy status.
+
+*rapl_power_limit* - keyword, number.long
+
+* _msr.rapl_power_limit_ - Run Time Average Power Limiting power limit.
+
+*rapl_power_units* - keyword, number.long
+
+* _msr.rapl_power_units_ - Run Time Average Power Limiting power units.
+
+*reactivated* - keyword, number.long
+
+* _virtual_memory_info.reactivated_ - Total number of reactivated pages.
+
+*read* - keyword, number.long
+
+* _docker_container_stats.read_ - UNIX time when stats were read
+
+*readonly* - keyword, number.long
+
+* _nfs_shares.readonly_ - 1 if the share is exported readonly else 0
+
+*readonly_rootfs* - keyword, number.long
+
+* _docker_containers.readonly_rootfs_ - Is the root filesystem mounted as read only
+
+*record_timestamp* - keyword, text.text
+
+* _ntfs_journal_events.record_timestamp_ - Journal record timestamp
+
+*record_usn* - keyword, text.text
+
+* _ntfs_journal_events.record_usn_ - The update sequence number that identifies the journal record
+
+*recovery_finish* - keyword, text.text
+
+* _md_devices.recovery_finish_ - Estimated duration of recovery activity
+
+*recovery_progress* - keyword, text.text
+
+* _md_devices.recovery_progress_ - Progress of the recovery activity
+
+*recovery_speed* - keyword, text.text
+
+* _md_devices.recovery_speed_ - Speed of recovery activity
+
+*redirect_accept* - keyword, number.long
+
+* _interface_ipv6.redirect_accept_ - Accept ICMP redirect messages
+
+*ref_pid* - keyword, number.long
+
+* _asl.ref_pid_ - Reference PID for messages proxied by launchd
+
+*ref_proc* - keyword, text.text
+
+* _asl.ref_proc_ - Reference process for messages proxied by launchd
+
+*referenced* - keyword, number.long
+
+* _chrome_extension_content_scripts.referenced_ - 1 if this extension is referenced by the Preferences file of the profile
+* _chrome_extensions.referenced_ - 1 if this extension is referenced by the Preferences file of the profile
+
+*referenced_identifier* - keyword, text.text
+
+* _chrome_extensions.referenced_identifier_ - Extension identifier, as specified by the preferences file. Empty if the extension is not in the profile.
+
+*refreshes* - keyword, number.long
+
+* _osquery_events.refreshes_ - Publisher only: number of runloop restarts
+
+*refs* - keyword, number.long
+
+* _kernel_extensions.refs_ - Reference count
+
+*region* - keyword, text.text
+
+* _ec2_instance_metadata.region_ - AWS region in which this instance launched
+
+*registers* - keyword, text.text
+
+* _crashes.registers_ - The value of the system registers
+* _kernel_panics.registers_ - A space delimited line of register:value pairs
+* _windows_crashes.registers_ - The values of the system registers
+
+*registry* - keyword, text.text
+
+* _osquery_registry.registry_ - Name of the osquery registry
+
+*registry_hive* - keyword, text.text
+
+* _logged_in_users.registry_hive_ - HKEY_USERS registry hive
+
+*registry_path* - keyword, text.text
+
+* _ie_extensions.registry_path_ - Extension identifier
+
+*relative_path* - keyword, text.text
+
+* _wmi_cli_event_consumers.relative_path_ - Relative path to the class or instance.
+* _wmi_event_filters.relative_path_ - Relative path to the class or instance.
+* _wmi_filter_consumer_binding.relative_path_ - Relative path to the class or instance.
+* _wmi_script_event_consumers.relative_path_ - Relative path to the class or instance.
+
+*release* - keyword, text.text
+
+* _apt_sources.release_ - Release name
+* _lxd_images.release_ - OS release version on which the image is based
+* _rpm_packages.release_ - Package release
+
+*remediation_path* - keyword, text.text
+
+* _windows_security_products.remediation_path_ - Remediation path
+
+*remote_address* - keyword, text.text
+
+* _bpf_socket_events.remote_address_ - Remote address associated with socket
+* _process_open_sockets.remote_address_ - Socket remote address
+* _socket_events.remote_address_ - Remote address associated with socket
+
+*remote_addresses* - keyword, text.text
+
+* _windows_firewall_rules.remote_addresses_ - Remote addresses for the rule
+
+*remote_apple_events* - keyword, number.long
+
+* _sharing_preferences.remote_apple_events_ - 1 If remote apple events are enabled else 0
+
+*remote_login* - keyword, number.long
+
+* _sharing_preferences.remote_login_ - 1 If remote login is enabled else 0
+
+*remote_management* - keyword, number.long
+
+* _sharing_preferences.remote_management_ - 1 If remote management is enabled else 0
+
+*remote_port* - keyword, number.long
+
+* _bpf_socket_events.remote_port_ - Remote network protocol port number
+* _process_open_sockets.remote_port_ - Socket remote port
+* _socket_events.remote_port_ - Remote network protocol port number
+
+*remote_ports* - keyword, text.text
+
+* _windows_firewall_rules.remote_ports_ - Remote ports for the rule
+
+*removable* - keyword, number.long
+
+* _usb_devices.removable_ - 1 If USB device is removable else 0
+
+*repository* - keyword, text.text
+
+* _portage_packages.repository_ - From which repository the ebuild was used
+
+*request_id* - keyword, text.text
+
+* _carves.request_id_ - Identifying value of the carve request (e.g., scheduled query name, distributed request, etc)
+
+*requested_mask* - keyword, text.text
+
+* _apparmor_events.requested_mask_ - Requested access mask
+
+*requirement* - keyword, text.text
+
+* _gatekeeper_approved_apps.requirement_ - Code signing requirement language
+
+*reservation_id* - keyword, text.text
+
+* _ec2_instance_metadata.reservation_id_ - ID of the reservation
+
+*reshape_finish* - keyword, text.text
+
+* _md_devices.reshape_finish_ - Estimated duration of reshape activity
+
+*reshape_progress* - keyword, text.text
+
+* _md_devices.reshape_progress_ - Progress of the reshape activity
+
+*reshape_speed* - keyword, text.text
+
+* _md_devices.reshape_speed_ - Speed of reshape activity
+
+*resident_size* - keyword, number.long
+
+* _docker_container_processes.resident_size_ - Bytes of private memory used by process
+* _processes.resident_size_ - Bytes of private memory used by process
+
+*resolution* - keyword, text.text
+
+* _connected_displays.resolution_ - The resolution of the display.
+
+*resource_group_name* - keyword, text.text
+
+* _azure_instance_metadata.resource_group_name_ - Resource group for the VM
+
+*response_code* - keyword, number.long
+
+* _curl.response_code_ - The HTTP status code for the response
+
+*responsible* - keyword, text.text
+
+* _crashes.responsible_ - Process responsible for the crashed process
+
+*result* - keyword, text.text
+
+* _authenticode.result_ - The signature check result
+* _curl.result_ - The HTTP response body
+
+*result_code* - keyword, text.text
+
+* _windows_update_history.result_code_ - Result of an operation on an update
+
+*resync_finish* - keyword, text.text
+
+* _md_devices.resync_finish_ - Estimated duration of resync activity
+
+*resync_progress* - keyword, text.text
+
+* _md_devices.resync_progress_ - Progress of the resync activity
+
+*resync_speed* - keyword, text.text
+
+* _md_devices.resync_speed_ - Speed of resync activity
+
+*retain_count* - keyword, number.long
+
+* _iokit_devicetree.retain_count_ - The device reference count
+* _iokit_registry.retain_count_ - The node reference count
+
+*revision* - keyword, text.text
+
+* _deb_packages.revision_ - Package revision
+* _hardware_events.revision_ - Device revision (optional)
+* _platform_info.revision_ - BIOS major and minor revision
+
+*roaming* - keyword, number.long
+
+* _wifi_networks.roaming_ - 1 if roaming is supported, 0 otherwise
+
+*roaming_profile* - keyword, text.text
+
+* _wifi_networks.roaming_profile_ - Describe the roaming profile, usually one of Single, Dual  or Multi
+
+*root* - keyword, text.text
+
+* _processes.root_ - Process virtual root directory
+
+*root_dir* - keyword, text.text
+
+* _docker_info.root_dir_ - Docker root directory
+
+*root_directory* - keyword, text.text
+
+* _launchd.root_directory_ - Key used to specify a directory to chroot to before launch
+
+*root_volume_uuid* - keyword, text.text
+
+* _time_machine_destinations.root_volume_uuid_ - Root UUID of backup volume
+
+*rotation* - keyword, text.text
+
+* _connected_displays.rotation_ - The orientation of the display.
+
+*round_trip_time* - keyword, number.long
+
+* _curl.round_trip_time_ - Time taken to complete the request
+
+*rowid* - keyword, number.long
+
+* _quicklook_cache.rowid_ - Quicklook file rowid key
+
+*rssi* - keyword, number.long
+
+* _wifi_status.rssi_ - The current received signal strength indication (dbm)
+* _wifi_survey.rssi_ - The current received signal strength indication (dbm)
+
+*rtadv_accept* - keyword, number.long
+
+* _interface_ipv6.rtadv_accept_ - Accept ICMP Router Advertisement
+
+*rule_details* - keyword, text.text
+
+* _sudoers.rule_details_ - Rule definition
+
+*run_at_load* - keyword, text.text
+
+* _launchd.run_at_load_ - Should the program run on launch load
+
+*run_count* - keyword, number.long
+
+* _prefetch.run_count_ - Number of times the application has been run.
+
+*rw* - keyword, number.long
+
+* _docker_container_mounts.rw_ - 1 if read/write. 0 otherwise
+
+*scheme* - keyword, text.text
+
+* _app_schemes.scheme_ - Name of the scheme/protocol
+
+*scope* - keyword, text.text
+
+* _selinux_settings.scope_ - Where the key is located inside the SELinuxFS mount point.
+
+*screen_sharing* - keyword, number.long
+
+* _sharing_preferences.screen_sharing_ - 1 If screen sharing is enabled else 0
+
+*script* - keyword, text.text
+
+* _chrome_extension_content_scripts.script_ - The content script used by the extension
+
+*script_block_count* - keyword, number.long
+
+* _powershell_events.script_block_count_ - The total number of script blocks for this script
+
+*script_block_id* - keyword, text.text
+
+* _powershell_events.script_block_id_ - The unique GUID of the powershell script to which this block belongs
+
+*script_file_name* - keyword, text.text
+
+* _wmi_script_event_consumers.script_file_name_ - Name of the file from which the script text is read, intended as an alternative to specifying the text of the script in the ScriptText property.
+
+*script_name* - keyword, text.text
+
+* _powershell_events.script_name_ - The name of the Powershell script
+
+*script_path* - keyword, text.text
+
+* _powershell_events.script_path_ - The path for the Powershell script
+
+*script_text* - keyword, text.text
+
+* _powershell_events.script_text_ - The text content of the Powershell script
+* _wmi_script_event_consumers.script_text_ - Text of the script that is expressed in a language known to the scripting engine. This property must be NULL if the ScriptFileName property is not NULL.
+
+*scripting_engine* - keyword, text.text
+
+* _wmi_script_event_consumers.scripting_engine_ - Name of the scripting engine to use, for example, 'VBScript'. This property cannot be NULL.
+
+*sdb_id* - keyword, text.text
+
+* _appcompat_shims.sdb_id_ - Unique GUID of the SDB.
+
+*sdk* - keyword, text.text
+
+* _browser_plugins.sdk_ - Build SDK used to compile plugin
+* _safari_extensions.sdk_ - Bundle SDK used to compile extension
+
+*sdk_version* - keyword, text.text
+
+* _osquery_extensions.sdk_version_ - osquery SDK version used to build the extension
+
+*seconds* - keyword, number.long
+
+* _time.seconds_ - Current seconds in UTC
+* _uptime.seconds_ - Seconds of uptime
+
+*section* - keyword, text.text
+
+* _deb_packages.section_ - Package section
+
+*secure_boot* - keyword, number.long
+
+* _secureboot.secure_boot_ - Whether secure boot is enabled
+
+*secure_mode* - keyword, number.long
+
+* _secureboot.secure_mode_ - (Intel) Secure mode: 0 disabled, 1 full security, 2 medium security
+
+*secure_process* - keyword, number.long
+
+* _processes.secure_process_ - Process is secure (IUM) yes=1, no=0
+
+*security_breach* - keyword, text.text
+
+* _chassis_info.security_breach_ - The physical status of the chassis such as Breach Successful, Breach Attempted, etc.
+
+*security_groups* - keyword, text.text
+
+* _ec2_instance_metadata.security_groups_ - Comma separated list of security group names
+
+*security_options* - keyword, text.text
+
+* _docker_containers.security_options_ - List of container security options
+
+*security_type* - keyword, text.text
+
+* _wifi_networks.security_type_ - Type of security on this network
+* _wifi_status.security_type_ - Type of security on this network
+
+*self_signed* - keyword, number.long
+
+* _certificates.self_signed_ - 1 if self-signed, else 0
+
+*sender* - keyword, text.text
+
+* _asl.sender_ - Sender's identification string.  Default is process name.
+* _unified_log.sender_ - the name of the binary image that made the entry
+
+*sensor_backend_server* - keyword, text.text
+
+* _carbon_black_info.sensor_backend_server_ - Carbon Black server
+
+*sensor_id* - keyword, number.long
+
+* _carbon_black_info.sensor_id_ - Sensor ID of the Carbon Black sensor
+
+*sensor_ip_addr* - keyword, text.text
+
+* _carbon_black_info.sensor_ip_addr_ - IP address of the sensor
+
+*seq_num* - keyword, number.long
+
+* _es_process_events.seq_num_ - Per event sequence number
+* _es_process_file_events.seq_num_ - Per event sequence number
+
+*serial* - keyword, text.text
+
+* _certificates.serial_ - Certificate serial number
+* _chassis_info.serial_ - The serial number of the chassis.
+* _disk_info.serial_ - The serial number of the disk.
+* _hardware_events.serial_ - Device serial (optional)
+* _usb_devices.serial_ - USB Device serial connection
+
+*serial_number* - keyword, text.text
+
+* _authenticode.serial_number_ - The certificate serial number
+* _battery.serial_number_ - The battery's unique serial number
+* _connected_displays.serial_number_ - The serial number of the display. (may not be unique)
+* _curl_certificate.serial_number_ - Certificate serial number
+* _kernel_keys.serial_number_ - The serial key of the key.
+* _memory_devices.serial_number_ - Serial number of memory device
+
+*serial_port_enabled* - keyword, text.text
+
+* _ycloud_instance_metadata.serial_port_enabled_ - Indicates if serial port is enabled for the VM
+
+*series* - keyword, text.text
+
+* _video_info.series_ - The series of the gpu.
+
+*server_name* - keyword, text.text
+
+* _lxd_cluster.server_name_ - Name of the LXD server node
+* _lxd_cluster_members.server_name_ - Name of the LXD server node
+
+*server_selection* - keyword, text.text
+
+* _windows_update_history.server_selection_ - Value that indicates which server provided an update
+
+*server_version* - keyword, text.text
+
+* _docker_info.server_version_ - Server version
+
+*service* - keyword, text.text
+
+* _drivers.service_ - Driver service name, if one exists
+* _interface_details.service_ - The name of the service the network adapter uses.
+* _iokit_devicetree.service_ - 1 if the device conforms to IOService else 0
+
+*service_exit_code* - keyword, number.long
+
+* _services.service_exit_code_ - The service-specific error code that the service returns when an error occurs while the service is starting or stopping
+
+*service_id* - keyword, text.text
+
+* _windows_update_history.service_id_ - Service identifier of an update service that is not a Windows update
+
+*service_key* - keyword, text.text
+
+* _drivers.service_key_ - Driver service registry key
+
+*service_name* - keyword, text.text
+
+* _windows_firewall_rules.service_name_ - Service name property of the application
+
+*service_type* - keyword, text.text
+
+* _services.service_type_ - Service Type: OWN_PROCESS, SHARE_PROCESS and maybe Interactive (can interact with the desktop)
+
+*ses* - keyword, number.long
+
+* _seccomp_events.ses_ - Session ID of the session from which the analyzed process was invoked
+
+*session_id* - keyword, number.long
+
+* _logon_sessions.session_id_ - The Terminal Services session identifier.
+* _process_etw_events.session_id_ - Session ID
+* _winbaseobj.session_id_ - Terminal Services Session Id
+
+*session_owner* - keyword, text.text
+
+* _authorizations.session_owner_ - Label top-level key
+
+*set* - keyword, number.long
+
+* _memory_devices.set_ - Identifies if memory device is one of a set of devices.  A value of 0 indicates no set affiliation.
+
+*setup_mode* - keyword, number.long
+
+* _secureboot.setup_mode_ - Whether setup mode is enabled
+
+*severity* - keyword, number.long
+
+* _syslog_events.severity_ - Syslog severity
+
+*sgid* - keyword
+
+* _docker_container_processes.sgid_ - Saved group ID
+* _process_events.sgid_ - Saved group ID at process start
+* _process_file_events.sgid_ - Saved group ID of the process using the file
+* _processes.sgid_ - Unsigned saved group ID
+
+*sha1* - keyword, text.text
+
+* _apparmor_profiles.sha1_ - A unique hash that identifies this policy.
+* _certificates.sha1_ - SHA1 hash of the raw certificate contents
+* _device_hash.sha1_ - SHA1 hash of provided inode data
+* _file_events.sha1_ - The SHA1 of the file after change
+* _hash.sha1_ - SHA1 hash of provided filesystem data
+* _rpm_packages.sha1_ - SHA1 hash of the package contents
+
+*sha1_fingerprint* - keyword, text.text
+
+* _curl_certificate.sha1_fingerprint_ - SHA1 fingerprint
+
+*sha256* - keyword, text.text
+
+* _carves.sha256_ - A SHA256 sum of the carved archive
+* _device_hash.sha256_ - SHA256 hash of provided inode data
+* _file_events.sha256_ - The SHA256 of the file after change
+* _hash.sha256_ - SHA256 hash of provided filesystem data
+* _rpm_package_files.sha256_ - SHA256 file digest from RPM info DB
+
+*sha256_fingerprint* - keyword, text.text
+
+* _curl_certificate.sha256_fingerprint_ - SHA-256 fingerprint
+
+*shard* - keyword, number.long
+
+* _osquery_packs.shard_ - Shard restriction limit, 1-100, 0 meaning no restriction
+
+*share* - keyword, text.text
+
+* _nfs_shares.share_ - Filesystem path to the share
+
+*shared* - keyword, text.text
+
+* _authorizations.shared_ - Label top-level key
+
+*shell* - keyword, text.text
+
+* _users.shell_ - User's configured default shell
+
+*shell_only* - keyword, number.long
+
+* _osquery_flags.shell_only_ - Is the flag shell only?
+
+*shmid* - keyword, number.long
+
+* _shared_memory.shmid_ - Shared memory segment ID
+
+*shortcut_comment* - keyword, text.text
+
+* _file.shortcut_comment_ - Comment on the shortcut
+
+*shortcut_run* - keyword, text.text
+
+* _file.shortcut_run_ - Window mode the target of the shortcut should be run in
+
+*shortcut_start_in* - keyword, text.text
+
+* _file.shortcut_start_in_ - Full path to the working directory to use when executing the shortcut target
+
+*shortcut_target_location* - keyword, text.text
+
+* _file.shortcut_target_location_ - Folder name where the shortcut target resides
+
+*shortcut_target_path* - keyword, text.text
+
+* _file.shortcut_target_path_ - Full path to the file the shortcut points to
+
+*shortcut_target_type* - keyword, text.text
+
+* _file.shortcut_target_type_ - Display name for the target type
+
+*sid* - keyword, text.text
+
+* _background_activities_moderator.sid_ - User SID.
+* _certificates.sid_ - SID
+* _logged_in_users.sid_ - The user's unique security identifier
+* _office_mru.sid_ - User SID
+* _shellbags.sid_ - User SID
+* _userassist.sid_ - User SID.
+
+*sig* - keyword, number.long
+
+* _seccomp_events.sig_ - Signal value sent to process by seccomp
+
+*sig_group* - keyword, text.text
+
+* _yara.sig_group_ - Signature group used
+
+*sigfile* - keyword, text.text
+
+* _yara.sigfile_ - Signature file used
+
+*signature* - keyword, text.text
+
+* _curl_certificate.signature_ - Signature
+
+*signature_algorithm* - keyword, text.text
+
+* _curl_certificate.signature_algorithm_ - Signature Algorithm
+
+*signatures_up_to_date* - keyword, number.long
+
+* _windows_security_products.signatures_up_to_date_ - 1 if product signatures are up to date, else 0
+
+*signed* - keyword, number.long
+
+* _drivers.signed_ - Whether the driver is signed or not
+* _signature.signed_ - 1 If the file is signed else 0
+
+*signing_algorithm* - keyword, text.text
+
+* _certificates.signing_algorithm_ - Signing algorithm used
+
+*signing_id* - keyword, text.text
+
+* _es_process_events.signing_id_ - Signature identifier of the process
+
+*sigrule* - keyword, text.text
+
+* _yara.sigrule_ - Signature strings used
+
+*sigurl* - keyword, text.text
+
+* _yara.sigurl_ - Signature url
+
+*size* - keyword
+
+* _acpi_tables.size_ - Size of compiled table data
+* _block_devices.size_ - Block device size in blocks
+* _carves.size_ - Size of the carved archive
+* _cups_jobs.size_ - The size of the print job
+* _deb_packages.size_ - Package size in bytes
+* _device_file.size_ - Size of file in bytes
+* _disk_events.size_ - Size of partition in bytes
+* _docker_image_history.size_ - Size of instruction in bytes
+* _file.size_ - Size of file in bytes
+* _file_events.size_ - Size of file in bytes
+* _kernel_extensions.size_ - Bytes of wired memory used by extension
+* _kernel_modules.size_ - Size of module content
+* _logical_drives.size_ - The total amount of space, in bytes, of the drive (-1 on failure).
+* _lxd_images.size_ - Size of image in bytes
+* _lxd_storage_pools.size_ - Size of the storage pool
+* _md_devices.size_ - size of the array in blocks
+* _memory_devices.size_ - Size of memory device in Megabyte
+* _package_bom.size_ - Expected file size
+* _platform_info.size_ - Size in bytes of firmware
+* _portage_packages.size_ - The size of the package
+* _prefetch.size_ - Application file size.
+* _quicklook_cache.size_ - Parsed version size field
+* _rpm_package_files.size_ - Expected file size in bytes from RPM info DB
+* _rpm_packages.size_ - Package size in bytes
+* _shared_memory.size_ - Size in bytes
+* _smbios_tables.size_ - Table entry size in bytes
+* _smc_keys.size_ - Reported size of data in bytes
+* _windows_search.size_ - The item size in bytes.
+
+*size_bytes* - keyword, number.long
+
+* _docker_images.size_bytes_ - Size of image in bytes
+
+*sku* - keyword, text.text
+
+* _azure_instance_metadata.sku_ - SKU for the VM image
+* _chassis_info.sku_ - The Stock Keeping Unit number if available.
+
+*slot* - keyword
+
+* _md_drives.slot_ - Slot position of disk
+* _portage_packages.slot_ - The slot used by package
+
+*smbios_tag* - keyword, text.text
+
+* _chassis_info.smbios_tag_ - The assigned asset tag number of the chassis.
+
+*socket* - keyword
+
+* _listening_ports.socket_ - Socket handle or inode number
+* _process_open_sockets.socket_ - Socket handle or inode number
+* _socket_events.socket_ - The local path (UNIX domain socket only)
+
+*socket_designation* - keyword, text.text
+
+* _cpu_info.socket_designation_ - The assigned socket on the board for the given CPU.
+
+*soft_limit* - keyword, text.text
+
+* _ulimit_info.soft_limit_ - Current limit value
+
+*softirq* - keyword, number.long
+
+* _cpu_time.softirq_ - Time spent servicing softirqs
+
+*sort* - keyword, text.text
+
+* _windows_search.sort_ - Sort for windows api
+
+*source* - keyword, text.text
+
+* _apt_sources.source_ - Source file
+* _autoexec.source_ - Source table of the autoexec item
+* _deb_packages.source_ - Package source
+* _docker_container_mounts.source_ - Source path on host
+* _lxd_storage_pools.source_ - Storage pool source
+* _package_install_history.source_ - Install source: usually the installer process name
+* _routes.source_ - Route source
+* _rpm_packages.source_ - Source RPM package name (optional)
+* _shellbags.source_ - Shellbags source Registry file
+* _startup_items.source_ - Directory or plist containing startup item
+* _sudoers.source_ - Source file containing the given rule
+* _windows_events.source_ - Source or channel of the event
+
+*source_path* - keyword, text.text
+
+* _systemd_units.source_path_ - Path to the (possibly generated) unit configuration file
+
+*source_url* - keyword, text.text
+
+* _firefox_addons.source_url_ - URL that installed the addon
+
+*space_total* - keyword, number.long
+
+* _lxd_storage_pools.space_total_ - Total available storage space in bytes for this storage pool
+
+*space_used* - keyword, number.long
+
+* _lxd_storage_pools.space_used_ - Storage space used in bytes
+
+*spare_disks* - keyword, number.long
+
+* _md_devices.spare_disks_ - Number of idle disks in array
+
+*spec_version* - keyword, text.text
+
+* _tpm_info.spec_version_ - Trusted Computing Group specification that the TPM supports
+
+*speculative* - keyword, number.long
+
+* _virtual_memory_info.speculative_ - Total number of speculative pages.
+
+*speed* - keyword, number.long
+
+* _interface_details.speed_ - Estimate of the current bandwidth in bits per second.
+
+*src_ip* - keyword, text.text
+
+* _iptables.src_ip_ - Source IP address.
+
+*src_mask* - keyword, text.text
+
+* _iptables.src_mask_ - Source IP address mask.
+
+*src_port* - keyword, text.text
+
+* _iptables.src_port_ - Protocol source port(s).
+
+*ssh_config_file* - keyword, text.text
+
+* _ssh_configs.ssh_config_file_ - Path to the ssh_config file
+
+*ssh_public_key* - keyword, text.text
+
+* _ec2_instance_metadata.ssh_public_key_ - SSH public key. Only available if supplied at instance launch time
+* _ycloud_instance_metadata.ssh_public_key_ - SSH public key. Only available if supplied at instance launch time
+
+*ssid* - keyword, text.text
+
+* _wifi_networks.ssid_ - SSID octets of the network
+* _wifi_status.ssid_ - SSID octets of the network
+* _wifi_survey.ssid_ - SSID octets of the network
+
+*stack_trace* - keyword, text.text
+
+* _crashes.stack_trace_ - Most recent frame from the stack trace
+* _windows_crashes.stack_trace_ - Multiple stack frames from the stack trace
+
+*start* - keyword, text.text
+
+* _memory_map.start_ - Start address of memory region
+* _process_memory_map.start_ - Virtual start address (hex)
+
+*start_interval* - keyword, text.text
+
+* _launchd.start_interval_ - Frequency to run in seconds
+
+*start_on_mount* - keyword, text.text
+
+* _launchd.start_on_mount_ - Run daemon or agent every time a filesystem is mounted
+
+*start_time* - keyword, number.long
+
+* _docker_container_processes.start_time_ - Process start in seconds since boot (non-sleeping)
+* _osquery_info.start_time_ - UNIX time in seconds when the process started
+* _processes.start_time_ - Process start time in seconds since Epoch, in case of error -1
+
+*start_type* - keyword, text.text
+
+* _services.start_type_ - Service start type: BOOT_START, SYSTEM_START, AUTO_START, DEMAND_START, DISABLED
+
+*started_at* - keyword, text.text
+
+* _docker_containers.started_at_ - Container start time as string
+
+*starting_address* - keyword, text.text
+
+* _memory_array_mapped_addresses.starting_address_ - Physical stating address, in kilobytes, of a range of memory mapped to physical memory array
+* _memory_device_mapped_addresses.starting_address_ - Physical stating address, in kilobytes, of a range of memory mapped to physical memory array
+
+*state* - keyword
+
+* _alf_exceptions.state_ - Firewall exception state
+* _battery.state_ - One of the following: "AC Power" indicates the battery is connected to an external power source, "Battery Power" indicates that the battery is drawing internal power, "Off Line" indicates the battery is off-line or no longer connected
+* _chrome_extensions.state_ - 1 if this extension is enabled
+* _docker_container_processes.state_ - Process state
+* _docker_containers.state_ - Container state (created, restarting, running, removing, paused, exited, dead)
+* _lxd_networks.state_ - Network status
+* _md_drives.state_ - State of the drive
+* _process_open_sockets.state_ - TCP socket state
+* _processes.state_ - Process state
+* _scheduled_tasks.state_ - State of the scheduled task
+* _system_extensions.state_ - System extension state
+* _windows_optional_features.state_ - Installation state value. 1 == Enabled, 2 == Disabled, 3 == Absent
+* _windows_security_products.state_ - State of protection
+
+*state_timestamp* - keyword, text.text
+
+* _windows_security_products.state_timestamp_ - Timestamp for the product state
+
+*stateful* - keyword, number.long
+
+* _lxd_instances.stateful_ - Whether the instance is stateful(1) or not(0)
+
+*statename* - keyword, text.text
+
+* _windows_optional_features.statename_ - Installation state name. 'Enabled','Disabled','Absent'
+
+*status* - keyword, text.text
+
+* _carves.status_ - Status of the carve, can be STARTING, PENDING, SUCCESS, or FAILED
+* _chassis_info.status_ - If available, gives various operational or nonoperational statuses such as OK, Degraded, and Pred Fail.
+* _deb_packages.status_ - Package status
+* _docker_containers.status_ - Container status information
+* _kernel_modules.status_ - Kernel module status
+* _lxd_cluster_members.status_ - Status of the node (Online/Offline)
+* _lxd_instances.status_ - Instance state (running, stopped, etc.)
+* _md_devices.status_ - Current state of the array
+* _ntdomains.status_ - The current status of the domain object.
+* _process_events.status_ - OpenBSM Attribute: Status of the process
+* _services.status_ - Service Current status: STOPPED, START_PENDING, STOP_PENDING, RUNNING, CONTINUE_PENDING, PAUSE_PENDING, PAUSED
+* _shared_memory.status_ - Destination/attach status
+* _shared_resources.status_ - String that indicates the current status of the object.
+* _socket_events.status_ - Either 'succeeded', 'failed', 'in_progress' (connect() on non-blocking socket) or 'no_client' (null accept() on non-blocking socket)
+* _startup_items.status_ - Startup status; either enabled or disabled
+
+*stderr_path* - keyword, text.text
+
+* _launchd.stderr_path_ - Pipe stderr to a target path
+
+*stdout_path* - keyword, text.text
+
+* _launchd.stdout_path_ - Pipe stdout to a target path
+
+*steal* - keyword, number.long
+
+* _cpu_time.steal_ - Time spent in other operating systems when running in a virtualized environment
+
+*stealth_enabled* - keyword, number.long
+
+* _alf.stealth_enabled_ - 1 If stealth mode is enabled else 0
+
+*stibp_support_enabled* - keyword, number.long
+
+* _kva_speculative_info.stibp_support_enabled_ - Windows uses STIBP.
+
+*storage* - keyword, number.long
+
+* _unified_log.storage_ - the storage category for the entry
+
+*storage_driver* - keyword, text.text
+
+* _docker_info.storage_driver_ - Storage driver
+
+*store* - keyword, text.text
+
+* _certificates.store_ - Certificate system store
+
+*store_id* - keyword, text.text
+
+* _certificates.store_id_ - Exists for service/user stores. Contains raw store id provided by WinAPI.
+
+*store_location* - keyword, text.text
+
+* _certificates.store_location_ - Certificate system store location
+
+*strings* - keyword, text.text
+
+* _yara.strings_ - Matching strings
+* _yara_events.strings_ - Matching strings
+
+*sub_state* - keyword, text.text
+
+* _systemd_units.sub_state_ - The low-level unit activation state, values depend on unit type
+
+*subclass* - keyword, text.text
+
+* _usb_devices.subclass_ - USB Device subclass
+
+*subject* - keyword, text.text
+
+* _certificates.subject_ - Certificate distinguished name (deprecated, use subject2)
+
+*subject2* - keyword, text.text
+
+* _certificates.subject2_ - Certificate distinguished name
+
+*subject_alternative_names* - keyword, text.text
+
+* _curl_certificate.subject_alternative_names_ - Subject Alternative Name
+
+*subject_info_access* - keyword, text.text
+
+* _curl_certificate.subject_info_access_ - Subject Information Access
+
+*subject_key_id* - keyword, text.text
+
+* _certificates.subject_key_id_ - SKID an optionally included SHA1
+
+*subject_key_identifier* - keyword, text.text
+
+* _curl_certificate.subject_key_identifier_ - Subject Key Identifier
+
+*subject_name* - keyword, text.text
+
+* _authenticode.subject_name_ - The certificate subject name
+
+*subkey* - keyword, text.text
+
+* _plist.subkey_ - Intermediate key path, includes lists/dicts
+* _preferences.subkey_ - Intemediate key path, includes lists/dicts
+
+*subnet* - keyword, text.text
+
+* _docker_networks.subnet_ - Network subnet
+
+*subscription_id* - keyword, text.text
+
+* _azure_instance_metadata.subscription_id_ - Azure subscription for the VM
+
+*subscriptions* - keyword, number.long
+
+* _osquery_events.subscriptions_ - Number of subscriptions the publisher received or subscriber used
+
+*subsystem* - keyword, text.text
+
+* _system_controls.subsystem_ - Subsystem ID, control type
+* _unified_log.subsystem_ - the subsystem of the os_log_t used
+
+*subsystem_model* - keyword, text.text
+
+* _pci_devices.subsystem_model_ - Device description of PCI device subsystem
+
+*subsystem_model_id* - keyword, text.text
+
+* _pci_devices.subsystem_model_id_ - Model ID of PCI device subsystem
+
+*subsystem_vendor* - keyword, text.text
+
+* _pci_devices.subsystem_vendor_ - Vendor of PCI device subsystem
+
+*subsystem_vendor_id* - keyword, text.text
+
+* _pci_devices.subsystem_vendor_id_ - Vendor ID of PCI device subsystem
+
+*success* - keyword, number.long
+
+* _socket_events.success_ - Deprecated. Use the 'status' column instead
+
+*suid* - keyword
+
+* _docker_container_processes.suid_ - Saved user ID
+* _process_events.suid_ - Saved user ID at process start
+* _process_file_events.suid_ - Saved user ID of the process using the file
+* _processes.suid_ - Unsigned saved user ID
+
+*summary* - keyword, text.text
+
+* _chocolatey_packages.summary_ - Package-supplied summary
+* _python_packages.summary_ - Package-supplied summary
+
+*superblock_state* - keyword, text.text
+
+* _md_devices.superblock_state_ - State of the superblock
+
+*superblock_update_time* - keyword, number.long
+
+* _md_devices.superblock_update_time_ - Unix timestamp of last update
+
+*superblock_version* - keyword, text.text
+
+* _md_devices.superblock_version_ - Version of the superblock
+
+*support_url* - keyword, text.text
+
+* _windows_update_history.support_url_ - Hyperlink to the language-specific support information for an update
+
+*swap_cached* - keyword, number.long
+
+* _memory_info.swap_cached_ - The amount of swap, in bytes, used as cache memory
+
+*swap_free* - keyword, number.long
+
+* _memory_info.swap_free_ - The total amount of swap free, in bytes
+
+*swap_ins* - keyword, number.long
+
+* _virtual_memory_info.swap_ins_ - The total number of compressed pages that have been swapped out to disk.
+
+*swap_limit* - keyword, number.long
+
+* _docker_info.swap_limit_ - 1 if swap limit support is enabled. 0 otherwise
+
+*swap_outs* - keyword, number.long
+
+* _virtual_memory_info.swap_outs_ - The total number of compressed pages that have been swapped back in from disk.
+
+*swap_total* - keyword, number.long
+
+* _memory_info.swap_total_ - The total amount of swap available, in bytes
+
+*symlink* - keyword, number.long
+
+* _file.symlink_ - 1 if the path is a symlink, otherwise 0
+
+*syscall* - keyword, text.text
+
+* _bpf_process_events.syscall_ - System call name
+* _bpf_socket_events.syscall_ - System call name
+* _process_events.syscall_ - Syscall name: fork, vfork, clone, execve, execveat
+* _seccomp_events.syscall_ - Type of the system call
+
+*system* - keyword, number.long
+
+* _cpu_time.system_ - Time spent in system mode
+
+*system_cpu_usage* - keyword, number.long
+
+* _docker_container_stats.system_cpu_usage_ - CPU system usage
+
+*system_model* - keyword, text.text
+
+* _kernel_panics.system_model_ - Physical system model, for example 'MacBookPro12,1 (Mac-E43C1C25D4880AD6)'
+
+*system_time* - keyword, number.long
+
+* _osquery_schedule.system_time_ - Total system time in milliseconds spent executing
+* _processes.system_time_ - CPU time in milliseconds spent in kernel space
+
+*tag* - keyword, text.text
+
+* _syslog_events.tag_ - The syslog tag
+
+*tags* - keyword, text.text
+
+* _docker_image_history.tags_ - Comma-separated list of tags
+* _docker_images.tags_ - Comma-separated list of repository tags
+* _yara.tags_ - Matching tags
+* _yara_events.tags_ - Matching tags
+
+*tapping_process* - keyword, number.long
+
+* _event_taps.tapping_process_ - The process ID of the application that created the event tap.
+
+*target* - keyword
+
+* _fan_speed_sensors.target_ - Target speed
+* _iptables.target_ - Target that applies for this rule.
+
+*target_name* - keyword, text.text
+
+* _prometheus_metrics.target_name_ - Address of prometheus target
+
+*target_path* - keyword, text.text
+
+* _file_events.target_path_ - The path associated with the event
+* _yara_events.target_path_ - The path scanned
+
+*task* - keyword, number.long
+
+* _windows_eventlog.task_ - Task value associated with the event
+* _windows_events.task_ - Task value associated with the event
+
+*team* - keyword, text.text
+
+* _system_extensions.team_ - Signing team ID
+
+*team_id* - keyword, text.text
+
+* _es_process_events.team_id_ - Team identifier of the process
+
+*team_identifier* - keyword, text.text
+
+* _signature.team_identifier_ - The team signing identifier sealed into the signature
+
+*temporarily_disabled* - keyword, number.long
+
+* _wifi_networks.temporarily_disabled_ - 1 if this network is temporarily disabled, 0 otherwise
+
+*terminal* - keyword, text.text
+
+* _user_events.terminal_ - The network protocol ID
+
+*threads* - keyword, number.long
+
+* _docker_container_processes.threads_ - Number of threads used by process
+* _processes.threads_ - Number of threads used by process
+
+*throttled* - keyword, number.long
+
+* _virtual_memory_info.throttled_ - Total number of throttled pages.
+
+*tid* - keyword, number.long
+
+* _bpf_process_events.tid_ - Thread ID
+* _bpf_socket_events.tid_ - Thread ID
+* _unified_log.tid_ - the tid of the thread that made the entry
+* _windows_crashes.tid_ - Thread ID of the crashed thread
+* _windows_eventlog.tid_ - Thread ID which emitted the event record
+
+*time* - keyword
+
+* _apparmor_events.time_ - Time of execution in UNIX time
+* _asl.time_ - Unix timestamp.  Set automatically
+* _bpf_process_events.time_ - Time of execution in UNIX time
+* _bpf_socket_events.time_ - Time of execution in UNIX time
+* _carves.time_ - Time at which the carve was kicked off
+* _disk_events.time_ - Time of appearance/disappearance in UNIX time
+* _docker_container_processes.time_ - Cumulative CPU time. [DD-]HH:MM:SS format
+* _es_process_events.time_ - Time of execution in UNIX time
+* _es_process_file_events.time_ - Time of execution in UNIX time
+* _file_events.time_ - Time of file event
+* _hardware_events.time_ - Time of hardware event
+* _kernel_panics.time_ - Formatted time of the event
+* _last.time_ - Entry timestamp
+* _logged_in_users.time_ - Time entry was made
+* _ntfs_journal_events.time_ - Time of file event
+* _package_install_history.time_ - Label date as UNIX timestamp
+* _powershell_events.time_ - Timestamp the event was received by the osquery event publisher
+* _process_etw_events.time_ - Event timestamp in Unix format
+* _process_events.time_ - Time of execution in UNIX time
+* _process_file_events.time_ - Time of execution in UNIX time
+* _seccomp_events.time_ - Time of execution in UNIX time
+* _selinux_events.time_ - Time of execution in UNIX time
+* _shell_history.time_ - Entry timestamp. It could be absent, default value is 0.
+* _socket_events.time_ - Time of execution in UNIX time
+* _syslog_events.time_ - Current unix epoch time
+* _user_events.time_ - Time of execution in UNIX time
+* _user_interaction_events.time_ - Time
+* _windows_events.time_ - Timestamp the event was received
+* _xprotect_reports.time_ - Quarantine alert time
+* _yara_events.time_ - Time of the scan
+
+*time_nano_sec* - keyword, number.long
+
+* _asl.time_nano_sec_ - Nanosecond time.
+
+*time_range* - keyword, text.text
+
+* _windows_eventlog.time_range_ - System time to selectively filter the events
+
+*time_windows* - keyword, number.long
+
+* _process_etw_events.time_windows_ - Event timestamp in Windows format
+
+*timeout* - keyword, text.text
+
+* _authorizations.timeout_ - Label top-level key
+* _curl_certificate.timeout_ - Set this value to the timeout in seconds to complete the TLS handshake (default 4s, use 0 for no timeout)
+* _kernel_keys.timeout_ - The amount of time until the key will expire,expressed in human-readable form. The string perm heremeans that the key is permanent (no timeout).  Thestring expd means that the key has already expired.
+
+*timestamp* - keyword, text.text
+
+* _time.timestamp_ - Current timestamp (log format) in UTC
+* _unified_log.timestamp_ - unix timestamp associated with the entry
+* _windows_eventlog.timestamp_ - Timestamp to selectively filter the events
+
+*timestamp_ms* - keyword, number.long
+
+* _prometheus_metrics.timestamp_ms_ - Unix timestamp of collected data in MS
+
+*timezone* - keyword, text.text
+
+* _time.timezone_ - Timezone for reported time (hardcoded to UTC)
+
+*title* - keyword, text.text
+
+* _cups_jobs.title_ - Title of the printed job
+* _windows_update_history.title_ - Title of an update
+
+*token_elevation_status* - keyword, number.long
+
+* _process_etw_events.token_elevation_status_ - Primary token elevation status - Present only on ProcessStart events
+
+*token_elevation_type* - keyword, text.text
+
+* _process_etw_events.token_elevation_type_ - Primary token elevation type - Present only on ProcessStart events
+
+*total_seconds* - keyword, number.long
+
+* _uptime.total_seconds_ - Total uptime seconds
+
+*total_size* - keyword, number.long
+
+* _docker_container_processes.total_size_ - Total virtual memory size
+* _processes.total_size_ - Total virtual memory size
+
+*total_width* - keyword, number.long
+
+* _memory_devices.total_width_ - Total width, in bits, of this memory device, including any check or error-correction bits
+
+*transaction_id* - keyword, number.long
+
+* _file_events.transaction_id_ - ID used during bulk update
+* _yara_events.transaction_id_ - ID used during bulk update
+
+*translated* - keyword, number.long
+
+* _processes.translated_ - Indicates whether the process is running under the Rosetta Translation Environment, yes=1, no=0, error=-1.
+
+*transmit_rate* - keyword, text.text
+
+* _wifi_status.transmit_rate_ - The current transmit rate
+
+*tries* - keyword, text.text
+
+* _authorizations.tries_ - Label top-level key
+
+*tty* - keyword, text.text
+
+* _last.tty_ - Entry terminal
+* _logged_in_users.tty_ - Device name
+
+*turbo_disabled* - keyword, number.long
+
+* _msr.turbo_disabled_ - Whether the turbo feature is disabled.
+
+*turbo_ratio_limit* - keyword, number.long
+
+* _msr.turbo_ratio_limit_ - The turbo feature ratio limit.
+
+*type* - keyword, text.text
+
+* _apparmor_events.type_ - Event type
+* _appcompat_shims.type_ - Type of the SDB database.
+* _block_devices.type_ - Block device type string
+* _bpf_socket_events.type_ - The socket type
+* _crashes.type_ - Type of crash log
+* _device_file.type_ - File status
+* _device_firmware.type_ - Type of device
+* _device_partitions.type_ - 
+* _disk_encryption.type_ - Description of cipher type and mode if available
+* _disk_info.type_ - The interface type of the disk.
+* _dns_cache.type_ - DNS record type
+* _dns_resolvers.type_ - Address type: sortlist, nameserver, search
+* _docker_container_mounts.type_ - Type of mount (bind, volume)
+* _docker_container_ports.type_ - Protocol (tcp, udp)
+* _docker_volumes.type_ - Volume type
+* _file.type_ - File status
+* _firefox_addons.type_ - Extension, addon, webapp
+* _hardware_events.type_ - Type of hardware and hardware event
+* _interface_addresses.type_ - Type of address. One of dhcp, manual, auto, other, unknown
+* _interface_details.type_ - Interface type (includes virtual)
+* _kernel_keys.type_ - The key type.
+* _keychain_items.type_ - Keychain item type (class)
+* _last.type_ - Entry type, according to ut_type types (utmp.h)
+* _logged_in_users.type_ - Login type
+* _logical_drives.type_ - Deprecated (always 'Unknown').
+* _lxd_certificates.type_ - Type of the certificate
+* _lxd_networks.type_ - Type of network
+* _mounts.type_ - Mounted device type
+* _ntfs_acl_permissions.type_ - Type of access mode for the access control entry.
+* _nvram.type_ - Data type (CFData, CFString, etc)
+* _osquery_events.type_ - Either publisher or subscriber
+* _osquery_extensions.type_ - SDK extension type: core, extension, or module
+* _osquery_flags.type_ - Flag type
+* _process_etw_events.type_ - Event Type (ProcessStart, ProcessStop)
+* _process_open_pipes.type_ - Pipe Type: named vs unnamed/anonymous
+* _registry.type_ - Type of the registry value, or 'subkey' if item is a subkey
+* _routes.type_ - Type of route
+* _selinux_events.type_ - Event type
+* _shared_resources.type_ - Type of resource being shared. Types include: disk drives, print queues, interprocess communications (IPC), and general devices.
+* _smbios_tables.type_ - Table entry type
+* _smc_keys.type_ - SMC-reported type literal type
+* _startup_items.type_ - Startup Item or Login Item
+* _system_controls.type_ - Data type
+* _ulimit_info.type_ - System resource to be limited
+* _user_events.type_ - The file description for the process socket
+* _users.type_ - Whether the account is roaming (domain), local, or a system profile
+* _windows_crashes.type_ - Type of crash log
+* _windows_search.type_ - The item type
+* _windows_security_products.type_ - Type of security product
+* _xprotect_meta.type_ - Either plugin or extension
+
+*type_name* - keyword, text.text
+
+* _last.type_name_ - Entry type name, according to ut_type types (utmp.h)
+* _shared_resources.type_name_ - Human readable value for the 'type' column
+
+*uid* - keyword
+
+* _account_policy_data.uid_ - User ID
+* _asl.uid_ - UID that sent the log message (set by the server).
+* _authorized_keys.uid_ - The local owner of authorized_keys file
+* _bpf_process_events.uid_ - User ID
+* _bpf_socket_events.uid_ - User ID
+* _browser_plugins.uid_ - The local user that owns the plugin
+* _chrome_extension_content_scripts.uid_ - The local user that owns the extension
+* _chrome_extensions.uid_ - The local user that owns the extension
+* _crashes.uid_ - User ID of the crashed process
+* _device_file.uid_ - Owning user ID
+* _disk_encryption.uid_ - Currently authenticated user if available
+* _docker_container_processes.uid_ - User ID
+* _es_process_events.uid_ - User ID of the process
+* _file.uid_ - Owning user ID
+* _file_events.uid_ - Owning user ID
+* _firefox_addons.uid_ - The local user that owns the addon
+* _kernel_keys.uid_ - The user ID of the key owner.
+* _known_hosts.uid_ - The local user that owns the known_hosts file
+* _launchd_overrides.uid_ - User ID applied to the override, 0 applies to all
+* _package_bom.uid_ - Expected user of file or directory
+* _password_policy.uid_ - User ID for the policy, -1 for policies that are global
+* _process_events.uid_ - User ID at process start
+* _process_file_events.uid_ - The uid of the process performing the action
+* _processes.uid_ - Unsigned user ID
+* _safari_extensions.uid_ - The local user that owns the extension
+* _seccomp_events.uid_ - User ID of the user who started the analyzed process
+* _shell_history.uid_ - Shell history owner
+* _ssh_configs.uid_ - The local owner of the ssh_config file
+* _user_events.uid_ - User ID
+* _user_groups.uid_ - User ID
+* _user_ssh_keys.uid_ - The local user that owns the key file
+* _users.uid_ - User ID
+* _vscode_extensions.uid_ - The local user that owns the plugin
+
+*uid_signed* - keyword, number.long
+
+* _users.uid_signed_ - User ID as int64 signed (Apple)
+
+*umci_policy_status* - keyword, text.text
+
+* _hvci_status.umci_policy_status_ - The status of the User Mode Code Integrity security settings. Returns UNKNOWN if an error is encountered.
+
+*uncompressed* - keyword, number.long
+
+* _virtual_memory_info.uncompressed_ - Total number of uncompressed pages.
+
+*uninstall_string* - keyword, text.text
+
+* _programs.uninstall_string_ - Path and filename of the uninstaller.
+
+*unique_chip_id* - keyword, text.text
+
+* _ibridge_info.unique_chip_id_ - Unique id of the iBridge controller
+
+*unit_file_state* - keyword, text.text
+
+* _systemd_units.unit_file_state_ - Whether the unit file is enabled, e.g. `enabled`, `masked`, `disabled`, etc
+
+*unix_time* - keyword, number.long
+
+* _time.unix_time_ - Current UNIX time in UTC
+
+*unmask* - keyword, number.long
+
+* _portage_keywords.unmask_ - If the package is unmasked
+
+*unused_devices* - keyword, text.text
+
+* _md_devices.unused_devices_ - Unused devices
+
+*update_id* - keyword, text.text
+
+* _windows_update_history.update_id_ - Revision-independent identifier of an update
+
+*update_revision* - keyword, number.long
+
+* _windows_update_history.update_revision_ - Revision number of an update
+
+*update_source_alias* - keyword, text.text
+
+* _lxd_images.update_source_alias_ - Alias of image at update source server
+
+*update_source_certificate* - keyword, text.text
+
+* _lxd_images.update_source_certificate_ - Certificate for update source server
+
+*update_source_protocol* - keyword, text.text
+
+* _lxd_images.update_source_protocol_ - Protocol used for image information update and image import from source server
+
+*update_source_server* - keyword, text.text
+
+* _lxd_images.update_source_server_ - Server for image update
+
+*update_url* - keyword, text.text
+
+* _chrome_extensions.update_url_ - Extension-supplied update URI
+* _safari_extensions.update_url_ - Extension-supplied update URI
+
+*upid* - keyword, number.long
+
+* _processes.upid_ - A 64bit pid that is never reused. Returns -1 if we couldn't gather them from the system.
+
+*uploaded_at* - keyword, text.text
+
+* _lxd_images.uploaded_at_ - ISO time of image upload
+
+*upn* - keyword, text.text
+
+* _logon_sessions.upn_ - The user principal name (UPN) for the owner of the logon session.
+
+*uppid* - keyword, number.long
+
+* _processes.uppid_ - The 64bit parent pid that is never reused. Returns -1 if we couldn't gather them from the system.
+
+*uptime* - keyword, number.long
+
+* _apparmor_events.uptime_ - Time of execution in system uptime
+* _kernel_panics.uptime_ - System uptime at kernel panic in nanoseconds
+* _process_events.uptime_ - Time of execution in system uptime
+* _process_file_events.uptime_ - Time of execution in system uptime
+* _seccomp_events.uptime_ - Time of execution in system uptime
+* _selinux_events.uptime_ - Time of execution in system uptime
+* _socket_events.uptime_ - Time of execution in system uptime
+* _user_events.uptime_ - Time of execution in system uptime
+
+*url* - keyword, text.text
+
+* _curl.url_ - The url for the request
+* _lxd_cluster_members.url_ - URL of the node
+
+*usage* - keyword, number.long
+
+* _kernel_keys.usage_ - the number of threads and open file references thatrefer to this key.
+
+*usb_address* - keyword, number.long
+
+* _usb_devices.usb_address_ - USB Device used address
+
+*usb_port* - keyword, number.long
+
+* _usb_devices.usb_port_ - USB Device used port
+
+*use* - keyword, text.text
+
+* _memory_arrays.use_ - Function for which the array is used
+* _portage_use.use_ - USE flag which has been enabled for package
+
+*used_by* - keyword, text.text
+
+* _kernel_modules.used_by_ - Module reverse dependencies
+* _lxd_networks.used_by_ - URLs for containers using this network
+
+*user* - keyword
+
+* _cpu_time.user_ - Time spent in user mode
+* _cups_jobs.user_ - The user who printed the job
+* _docker_container_processes.user_ - User name
+* _logged_in_users.user_ - User login name
+* _logon_sessions.user_ - The account name of the security principal that owns the logon session.
+* _sandboxes.user_ - Sandbox owner
+* _systemd_units.user_ - The configured user, if any
+
+*user_account* - keyword, text.text
+
+* _services.user_account_ - The name of the account that the service process will be logged on as when it runs. This name can be of the form Domain\UserName. If the account belongs to the built-in domain, the name can be of the form .\UserName.
+
+*user_account_control* - keyword, text.text
+
+* _windows_security_center.user_account_control_ - The health of the User Account Control (UAC) capability in Windows
+
+*user_action* - keyword, text.text
+
+* _xprotect_reports.user_action_ - Action taken by user after prompted
+
+*user_agent* - keyword, text.text
+
+* _curl.user_agent_ - The user-agent string to use for the request
+
+*user_namespace* - keyword, text.text
+
+* _docker_containers.user_namespace_ - User namespace
+* _process_namespaces.user_namespace_ - user namespace inode
+
+*user_time* - keyword, number.long
+
+* _osquery_schedule.user_time_ - Total user time in milliseconds spent executing
+* _processes.user_time_ - CPU time in milliseconds spent in user space
+
+*user_uuid* - keyword, text.text
+
+* _disk_encryption.user_uuid_ - UUID of authenticated user if available
+
+*username* - keyword, text.text
+
+* _certificates.username_ - Username
+* _es_process_events.username_ - Username
+* _last.username_ - Entry username
+* _launchd.username_ - Run this daemon or agent as this username
+* _managed_policies.username_ - Policy applies only this user
+* _preferences.username_ - (optional) read preferences for a specific user
+* _process_etw_events.username_ - User rights - primary token username
+* _rpm_package_files.username_ - File default username from info DB
+* _shadow.username_ - Username
+* _startup_items.username_ - The user associated with the startup item
+* _suid_bin.username_ - Binary owner username
+* _users.username_ - Username
+* _windows_crashes.username_ - Username of the user who ran the crashed process
+
+*uses_pattern* - keyword, number.long
+
+* _xprotect_entries.uses_pattern_ - Uses a match pattern instead of identity
+
+*uts_namespace* - keyword, text.text
+
+* _docker_containers.uts_namespace_ - UTS namespace
+* _process_namespaces.uts_namespace_ - uts namespace inode
+
+*uuid* - keyword, text.text
+
+* _block_devices.uuid_ - Block device Universally Unique Identifier
+* _disk_encryption.uuid_ - Disk Universally Unique Identifier
+* _disk_events.uuid_ - UUID of the volume inside DMG if available
+* _managed_policies.uuid_ - Optional UUID assigned to policy set
+* _osquery_extensions.uuid_ - The transient ID assigned for communication
+* _osquery_info.uuid_ - Unique ID provided by the system
+* _system_info.uuid_ - Unique ID provided by the system
+* _users.uuid_ - User's UUID (Apple) or SID (Windows)
+* _vscode_extensions.uuid_ - Extension UUID
+
+*valid_from* - keyword, text.text
+
+* _curl_certificate.valid_from_ - Period of validity start date
+
+*valid_to* - keyword, text.text
+
+* _curl_certificate.valid_to_ - Period of validity end date
+
+*value* - keyword, text.text
+
+* _ad_config.value_ - Variable typed option value
+* _augeas.value_ - The value of the configuration item
+* _azure_instance_tags.value_ - The tag value
+* _cpuid.value_ - Bit value or string
+* _default_environment.value_ - Value of the environment variable
+* _docker_container_envs.value_ - Environment variable value
+* _docker_container_labels.value_ - Optional label value
+* _docker_image_labels.value_ - Optional label value
+* _docker_network_labels.value_ - Optional label value
+* _docker_volume_labels.value_ - Optional label value
+* _ec2_instance_tags.value_ - Tag value
+* _extended_attributes.value_ - The parsed information from the attribute
+* _launchd_overrides.value_ - Overridden value
+* _lxd_instance_config.value_ - Configuration parameter value
+* _lxd_instance_devices.value_ - Device info param value
+* _managed_policies.value_ - Policy value
+* _mdls.value_ - Value stored in the metadata key
+* _nvram.value_ - Raw variable data
+* _oem_strings.value_ - The value of the OEM string
+* _osquery_flags.value_ - Flag value
+* _plist.value_ - String value of most CF types
+* _power_sensors.value_ - Power in Watts
+* _preferences.value_ - String value of most CF types
+* _process_envs.value_ - Environment variable value
+* _selinux_settings.value_ - Active value.
+* _smc_keys.value_ - A type-encoded representation of the key value
+* _wmi_bios_info.value_ - Value of the Bios setting
+
+*valuetype* - keyword, text.text
+
+* _mdls.valuetype_ - CoreFoundation type of data stored in value
+
+*variable* - keyword, text.text
+
+* _default_environment.variable_ - Name of the environment variable
+
+*vbs_status* - keyword, text.text
+
+* _hvci_status.vbs_status_ - The status of the virtualization based security settings. Returns UNKNOWN if an error is encountered.
+
+*vendor* - keyword, text.text
+
+* _block_devices.vendor_ - Block device vendor string
+* _disk_events.vendor_ - Disk event vendor string
+* _hardware_events.vendor_ - Hardware device vendor
+* _pci_devices.vendor_ - PCI Device vendor
+* _platform_info.vendor_ - Platform code vendor
+* _rpm_packages.vendor_ - Package vendor
+* _usb_devices.vendor_ - USB Device vendor string
+
+*vendor_id* - keyword, text.text
+
+* _connected_displays.vendor_id_ - The vendor ID of the display.
+* _hardware_events.vendor_id_ - Hex encoded Hardware vendor identifier
+* _pci_devices.vendor_id_ - Hex encoded PCI Device vendor identifier
+* _usb_devices.vendor_id_ - Hex encoded USB Device vendor identifier
+
+*vendor_syndrome* - keyword, text.text
+
+* _memory_error_info.vendor_syndrome_ - Vendor specific ECC syndrome or CRC data associated with the erroneous access
+
+*version* - keyword, text.text
+
+* _alf.version_ - Application Layer Firewall version
+* _apt_sources.version_ - Repository source version
+* _authorizations.version_ - Label top-level key
+* _azure_instance_metadata.version_ - Version of the VM image
+* _bitlocker_info.version_ - The FVE metadata version of the drive.
+* _browser_plugins.version_ - Plugin short version
+* _chocolatey_packages.version_ - Package-supplied version
+* _chrome_extension_content_scripts.version_ - Extension-supplied version
+* _chrome_extensions.version_ - Extension-supplied version
+* _crashes.version_ - Version info of the crashed process
+* _curl_certificate.version_ - Version Number
+* _deb_packages.version_ - Package version
+* _device_firmware.version_ - Firmware version
+* _docker_version.version_ - Docker version
+* _drivers.version_ - Driver version
+* _es_process_events.version_ - Version of EndpointSecurity event
+* _es_process_file_events.version_ - Version of EndpointSecurity event
+* _firefox_addons.version_ - Addon-supplied version string
+* _gatekeeper.version_ - Version of Gatekeeper's gke.bundle
+* _homebrew_packages.version_ - Current 'linked' version
+* _hvci_status.version_ - The version number of the Device Guard build.
+* _ie_extensions.version_ - Version of the executable
+* _intel_me_info.version_ - Intel ME version
+* _kernel_extensions.version_ - Extension version
+* _kernel_info.version_ - Kernel version
+* _npm_packages.version_ - Package-supplied version
+* _office_mru.version_ - Office application version number
+* _os_version.version_ - Pretty, suitable for presentation, OS version
+* _osquery_extensions.version_ - Extension's version
+* _osquery_info.version_ - osquery toolkit version
+* _osquery_packs.version_ - Minimum osquery version that this query will run on
+* _package_install_history.version_ - Package display version
+* _package_receipts.version_ - Installed package version
+* _platform_info.version_ - Platform code version
+* _portage_keywords.version_ - The version which are affected by the use flags, empty means all
+* _portage_packages.version_ - The version which are affected by the use flags, empty means all
+* _portage_use.version_ - The version of the installed package
+* _programs.version_ - Product version information.
+* _python_packages.version_ - Package-supplied version
+* _rpm_packages.version_ - Package version
+* _safari_extensions.version_ - Extension long version
+* _system_extensions.version_ - System extension version
+* _usb_devices.version_ - USB Device version number
+* _vscode_extensions.version_ - Extension version
+* _windows_crashes.version_ - File version info of the crashed process
+
+*video_mode* - keyword, text.text
+
+* _video_info.video_mode_ - The current resolution of the display.
+
+*virtual_process* - keyword, number.long
+
+* _processes.virtual_process_ - Process is virtual (e.g. System, Registry, vmmem) yes=1, no=0
+
+*visible* - keyword, number.long
+
+* _firefox_addons.visible_ - 1 If the addon is shown in browser else 0
+
+*visible_alarm* - keyword, text.text
+
+* _chassis_info.visible_alarm_ - If TRUE, the frame is equipped with a visual alarm.
+
+*vm_id* - keyword, text.text
+
+* _azure_instance_metadata.vm_id_ - Unique identifier for the VM
+* _azure_instance_tags.vm_id_ - Unique identifier for the VM
+
+*vm_scale_set_name* - keyword, text.text
+
+* _azure_instance_metadata.vm_scale_set_name_ - VM scale set name
+
+*vm_size* - keyword, text.text
+
+* _azure_instance_metadata.vm_size_ - VM size
+
+*voltage* - keyword, number.long
+
+* _battery.voltage_ - The battery's current voltage in mV
+
+*volume_creation* - keyword, text.text
+
+* _prefetch.volume_creation_ - Volume creation time.
+
+*volume_id* - keyword, number.long
+
+* _quicklook_cache.volume_id_ - Parsed volume ID from fs_id
+
+*volume_serial* - keyword, text.text
+
+* _file.volume_serial_ - Volume serial number
+* _prefetch.volume_serial_ - Volume serial number.
+
+*volume_size* - keyword, number.long
+
+* _platform_info.volume_size_ - (Optional) size of firmware volume
+
+*wall_time* - keyword, number.long
+
+* _osquery_schedule.wall_time_ - Total wall time in seconds spent executing (deprecated), hidden=True
+
+*wall_time_ms* - keyword, number.long
+
+* _osquery_schedule.wall_time_ms_ - Total wall time in milliseconds spent executing
+
+*warning* - keyword, number.long
+
+* _shadow.warning_ - Number of days before password expires to warn user about it
+
+*was_captive_network* - keyword, number.long
+
+* _wifi_networks.was_captive_network_ - 1 if this network was previously a captive network, 0 otherwise
+
+*watch_paths* - keyword, text.text
+
+* _launchd.watch_paths_ - Key that launches daemon or agent if path is modified
+
+*watcher* - keyword, number.long
+
+* _osquery_info.watcher_ - Process (or thread/handle) ID of optional watcher process
+
+*weekday* - keyword, text.text
+
+* _time.weekday_ - Current weekday in UTC
+
+*win32_exit_code* - keyword, number.long
+
+* _services.win32_exit_code_ - The error code that the service uses to report an error that occurs when it is starting or stopping
+
+*win_timestamp* - keyword, number.long
+
+* _time.win_timestamp_ - Timestamp value in 100 nanosecond units
+
+*windows_security_center_service* - keyword, text.text
+
+* _windows_security_center.windows_security_center_service_ - The health of the Windows Security Center Service
+
+*wired* - keyword, number.long
+
+* _virtual_memory_info.wired_ - Total number of wired down pages.
+
+*wired_size* - keyword, number.long
+
+* _docker_container_processes.wired_size_ - Bytes of unpageable memory used by process
+* _processes.wired_size_ - Bytes of unpageable memory used by process
+
+*working_directory* - keyword, text.text
+
+* _launchd.working_directory_ - Key used to specify a directory to chdir to before launch
+
+*working_disks* - keyword, number.long
+
+* _md_devices.working_disks_ - Number of working disks in array
+
+*world* - keyword, number.long
+
+* _portage_packages.world_ - If package is in the world file
+
+*writable* - keyword, number.long
+
+* _disk_events.writable_ - 1 if writable, 0 if not
+
+*xpath* - keyword, text.text
+
+* _windows_eventlog.xpath_ - The custom query to filter events
+
+*year* - keyword, number.long
+
+* _time.year_ - Current year in UTC
+
+*zero_fill* - keyword, number.long
+
+* _virtual_memory_info.zero_fill_ - Total number of zero filled pages.
+
+*zone* - keyword, text.text
+
+* _azure_instance_metadata.zone_ - Availability zone of the VM
+* _ycloud_instance_metadata.zone_ - Availability zone of the VM
+
+
+*UUID* - keyword, text.text
+
+* _system_extensions.UUID_ - Extension unique id
+
+*access* - keyword, text.text
+
+* _ntfs_acl_permissions.access_ - Specific permissions that indicate the rights described by the ACE.
+
+*accessed_directories* - keyword, text.text
+
+* _prefetch.accessed_directories_ - Directories accessed by application within ten seconds of launch.
+
+*accessed_directories_count* - keyword, number.long
+
+* _prefetch.accessed_directories_count_ - Number of directories accessed.
+
+*accessed_files* - keyword, text.text
+
+* _prefetch.accessed_files_ - Files accessed by application within ten seconds of launch.
+
+*accessed_files_count* - keyword, number.long
+
+* _prefetch.accessed_files_count_ - Number of files accessed.
+
+*accessed_time* - keyword, number.long
+
+* _shellbags.accessed_time_ - Directory Accessed time.
+
+*account* - keyword, text.text
+
+* _keychain_items.account_ - Optional item account
+
+*account_id* - keyword, text.text
+
+* _ec2_instance_metadata.account_id_ - AWS account ID which owns this EC2 instance
+
+*action* - keyword, text.text
+
+* _disk_events.action_ - Appear or disappear
+* _file_events.action_ - Change action (UPDATE, REMOVE, etc)
+* _hardware_events.action_ - Remove, insert, change properties, etc
+* _ntfs_journal_events.action_ - Change action (Write, Delete, etc)
+* _scheduled_tasks.action_ - Actions executed by the scheduled task
+* _socket_events.action_ - The socket action (bind, listen, close)
+* _windows_firewall_rules.action_ - Action for the rule or default setting
+* _yara_events.action_ - Change action (UPDATE, REMOVE, etc)
+
+*activated* - keyword, number.long
+
+* _tpm_info.activated_ - TPM is activated
+
+*active* - keyword, number.long
+
+* _firefox_addons.active_ - 1 If the addon is active else 0
+* _memory_info.active_ - The total amount of buffer or page cache memory, in bytes, that is in active use
+* _osquery_events.active_ - 1 if the publisher or subscriber is active else 0
+* _osquery_packs.active_ - Whether this pack is active (the version, platform and discovery queries match) yes=1, no=0.
+* _osquery_registry.active_ - 1 If this plugin is active else 0
+* _virtual_memory_info.active_ - Total number of active pages.
+
+*active_disks* - keyword, number.long
+
+* _md_devices.active_disks_ - Number of active disks in array
+
+*active_state* - keyword, text.text
+
+* _systemd_units.active_state_ - The high-level unit activation state, i.e. generalization of SUB
+
+*activity* - keyword, number.long
+
+* _unified_log.activity_ - the activity ID associate with the entry
+
+*actual* - keyword, number.long
+
+* _fan_speed_sensors.actual_ - Actual speed
+
+*add_reason* - keyword, text.text
+
+* _wifi_networks.add_reason_ - Shows why this network was added, via menubar or command line or something else 
+
+*added_at* - keyword, number.long
+
+* _wifi_networks.added_at_ - Time this network was added as a unix_time
+
+*additional_properties* - keyword, text.text
+
+* _windows_search.additional_properties_ - Comma separated list of columns to include in properties JSON
+
+*address* - keyword, text.text
+
+* _arp_cache.address_ - IPv4 address target
+* _dns_resolvers.address_ - Resolver IP/IPv6 address
+* _etc_hosts.address_ - IP address mapping
+* _interface_addresses.address_ - Specific address for interface
+* _kernel_modules.address_ - Kernel module address
+* _listening_ports.address_ - Specific address for bind
+* _platform_info.address_ - Relative address of firmware mapping
+* _user_events.address_ - The Internet protocol address or family ID
+
+*address_width* - keyword, text.text
+
+* _cpu_info.address_width_ - The width of the CPU address bus.
+
+*admindir* - keyword, text.text
+
+* _deb_packages.admindir_ - libdpkg admindir. Defaults to /var/lib/dpkg
+
+*algorithm* - keyword, text.text
+
+* _authorized_keys.algorithm_ - Key type
+
+*alias* - keyword, text.text
+
+* _etc_protocols.alias_ - Protocol alias
+* _time_machine_destinations.alias_ - Human readable name of drive
+
+*aliases* - keyword, text.text
+
+* _etc_services.aliases_ - Optional space separated list of other names for a service
+* _lxd_images.aliases_ - Comma-separated list of image aliases
+
+*allow_maximum* - keyword, number.long
+
+* _shared_resources.allow_maximum_ - Number of concurrent users for this resource has been limited. If True, the value in the MaximumAllowed property is ignored.
+
+*allow_root* - keyword, text.text
+
+* _authorizations.allow_root_ - Label top-level key
+
+*allow_signed_enabled* - keyword, number.long
+
+* _alf.allow_signed_enabled_ - 1 If allow signed mode is enabled else 0 (not supported on macOS 15+)
+
+*ambient_brightness_enabled* - keyword, text.text
+
+* _connected_displays.ambient_brightness_enabled_ - The ambient brightness setting associated with the display. This will be 1 if enabled and is 0 if disabled or not supported.
+
+*ami_id* - keyword, text.text
+
+* _ec2_instance_metadata.ami_id_ - AMI ID used to launch this EC2 instance
+
+*amperage* - keyword, number.long
+
+* _battery.amperage_ - The current amperage in/out of the battery in mA (positive means charging, negative means discharging)
+
+*anonymous* - keyword, number.long
+
+* _virtual_memory_info.anonymous_ - Total number of anonymous pages.
+
+*antispyware* - keyword, text.text
+
+* _windows_security_center.antispyware_ - Deprecated (always 'Good').
+
+*antivirus* - keyword, text.text
+
+* _windows_security_center.antivirus_ - The health of the monitored Antivirus solution (see windows_security_products)
+
+*api_version* - keyword, text.text
+
+* _docker_version.api_version_ - API version
+
+*app_name* - keyword, text.text
+
+* _windows_firewall_rules.app_name_ - Friendly name of the application to which the rule applies
+
+*apparmor* - keyword, text.text
+
+* _apparmor_events.apparmor_ - Apparmor Status like ALLOWED, DENIED etc.
+
+*applescript_enabled* - keyword, text.text
+
+* _apps.applescript_enabled_ - Info properties NSAppleScriptEnabled label
+
+*application* - keyword, text.text
+
+* _office_mru.application_ - Associated Office application
+
+*arch* - keyword, text.text
+
+* _deb_packages.arch_ - Package architecture
+* _docker_version.arch_ - Hardware architecture
+* _os_version.arch_ - OS Architecture
+* _rpm_packages.arch_ - Architecture(s) supported
+* _seccomp_events.arch_ - Information about the CPU architecture
+* _signature.arch_ - If applicable, the arch of the signed code
+
+*architecture* - keyword, text.text
+
+* _docker_info.architecture_ - Hardware architecture
+* _ec2_instance_metadata.architecture_ - Hardware architecture of this EC2 instance
+* _lxd_images.architecture_ - Target architecture for the image
+* _lxd_instances.architecture_ - Instance architecture
+
+*architectures* - keyword, text.text
+
+* _apt_sources.architectures_ - Repository architectures
+
+*args* - keyword, text.text
+
+* _startup_items.args_ - Arguments provided to startup executable
+
+*arguments* - keyword, text.text
+
+* _kernel_info.arguments_ - Kernel arguments
+
+*array_handle* - keyword, text.text
+
+* _memory_devices.array_handle_ - The memory array that the device is attached to
+
+*assessments_enabled* - keyword, number.long
+
+* _gatekeeper.assessments_enabled_ - 1 If a Gatekeeper is enabled else 0
+
+*asset_tag* - keyword, text.text
+
+* _memory_devices.asset_tag_ - Manufacturer specific asset tag of memory device
+
+*atime* - keyword, number.long
+
+* _device_file.atime_ - Last access time
+* _file.atime_ - Last access time
+* _file_events.atime_ - Last access time
+* _process_events.atime_ - File last access in UNIX time
+* _shared_memory.atime_ - Attached time
+
+*attach* - keyword, text.text
+
+* _apparmor_profiles.attach_ - Which executable(s) a profile will attach to.
+
+*attached* - keyword, number.long
+
+* _shared_memory.attached_ - Number of attached processes
+
+*attributes* - keyword, text.text
+
+* _file.attributes_ - File attrib string. See: https://ss64.com/nt/attrib.html
+
+*audible_alarm* - keyword, text.text
+
+* _chassis_info.audible_alarm_ - If TRUE, the frame is equipped with an audible alarm.
+
+*audit_account_logon* - keyword, number.long
+
+* _security_profile_info.audit_account_logon_ - Determines whether the operating system MUST audit each time this computer validates the credentials of an account
+
+*audit_account_manage* - keyword, number.long
+
+* _security_profile_info.audit_account_manage_ - Determines whether the operating system MUST audit each event of account management on a computer
+
+*audit_ds_access* - keyword, number.long
+
+* _security_profile_info.audit_ds_access_ - Determines whether the operating system MUST audit each instance of user attempts to access an Active Directory object that has its own system access control list (SACL) specified
+
+*audit_logon_events* - keyword, number.long
+
+* _security_profile_info.audit_logon_events_ - Determines whether the operating system MUST audit each instance of a user attempt to log on or log off this computer
+
+*audit_object_access* - keyword, number.long
+
+* _security_profile_info.audit_object_access_ - Determines whether the operating system MUST audit each instance of user attempts to access a non-Active Directory object that has its own SACL specified
+
+*audit_policy_change* - keyword, number.long
+
+* _security_profile_info.audit_policy_change_ - Determines whether the operating system MUST audit each instance of user attempts to change user rights assignment policy, audit policy, account policy, or trust policy
+
+*audit_privilege_use* - keyword, number.long
+
+* _security_profile_info.audit_privilege_use_ - Determines whether the operating system MUST audit each instance of user attempts to exercise a user right
+
+*audit_process_tracking* - keyword, number.long
+
+* _security_profile_info.audit_process_tracking_ - Determines whether the operating system MUST audit process-related events
+
+*audit_system_events* - keyword, number.long
+
+* _security_profile_info.audit_system_events_ - Determines whether the operating system MUST audit System Change, System Startup, System Shutdown, Authentication Component Load, and Loss or Excess of Security events
+
+*auid* - keyword
+
+* _process_events.auid_ - Audit User ID at process start
+* _process_file_events.auid_ - Audit user ID of the process using the file
+* _seccomp_events.auid_ - Audit user ID (loginuid) of the user who started the analyzed process
+* _socket_events.auid_ - Audit User ID
+* _user_events.auid_ - Audit User ID
+
+*authenticate_user* - keyword, text.text
+
+* _authorizations.authenticate_user_ - Label top-level key
+
+*authentication_package* - keyword, text.text
+
+* _logon_sessions.authentication_package_ - The authentication package used to authenticate the owner of the logon session.
+
+*author* - keyword, text.text
+
+* _chocolatey_packages.author_ - Optional package author
+* _chrome_extensions.author_ - Optional extension author
+* _npm_packages.author_ - Package-supplied author
+* _python_packages.author_ - Optional package author
+
+*authority* - keyword, text.text
+
+* _signature.authority_ - Certificate Common Name
+
+*authority_key_id* - keyword, text.text
+
+* _certificates.authority_key_id_ - AKID an optionally included SHA1
+
+*authority_key_identifier* - keyword, text.text
+
+* _curl_certificate.authority_key_identifier_ - Authority Key Identifier
+
+*authorizations* - keyword, text.text
+
+* _keychain_acls.authorizations_ - A space delimited set of authorization attributes
+
+*auto_join* - keyword, number.long
+
+* _wifi_networks.auto_join_ - 1 if this network set to join automatically, 0 otherwise
+
+*auto_login* - keyword, number.long
+
+* _wifi_networks.auto_login_ - 1 if auto login is enabled, 0 otherwise
+
+*auto_update* - keyword, number.long
+
+* _lxd_images.auto_update_ - Whether the image auto-updates (1) or not (0)
+
+*autoupdate* - keyword
+
+* _firefox_addons.autoupdate_ - 1 If the addon applies background updates else 0
+* _windows_security_center.autoupdate_ - The health of the Windows Autoupdate feature
+
+*availability* - keyword, text.text
+
+* _cpu_info.availability_ - The availability and status of the CPU.
+
+*availability_zone* - keyword, text.text
+
+* _ec2_instance_metadata.availability_zone_ - Availability zone in which this instance launched
+
+*average* - keyword, text.text
+
+* _load_average.average_ - Load average over the specified period.
+
+*average_memory* - keyword, number.long
+
+* _osquery_schedule.average_memory_ - Average of the bytes of resident memory left allocated after collecting results
+
+*avg_disk_bytes_per_read* - keyword, number.long
+
+* _physical_disk_performance.avg_disk_bytes_per_read_ - Average number of bytes transferred from the disk during read operations
+
+*avg_disk_bytes_per_write* - keyword, number.long
+
+* _physical_disk_performance.avg_disk_bytes_per_write_ - Average number of bytes transferred to the disk during write operations
+
+*avg_disk_read_queue_length* - keyword, number.long
+
+* _physical_disk_performance.avg_disk_read_queue_length_ - Average number of read requests that were queued for the selected disk during the sample interval
+
+*avg_disk_sec_per_read* - keyword, number.long
+
+* _physical_disk_performance.avg_disk_sec_per_read_ - Average time, in seconds, of a read operation of data from the disk
+
+*avg_disk_sec_per_write* - keyword, number.long
+
+* _physical_disk_performance.avg_disk_sec_per_write_ - Average time, in seconds, of a write operation of data to the disk
+
+*avg_disk_write_queue_length* - keyword, number.long
+
+* _physical_disk_performance.avg_disk_write_queue_length_ - Average number of write requests that were queued for the selected disk during the sample interval
+
+*backup_date* - keyword, number.long
+
+* _time_machine_backups.backup_date_ - Backup Date
+
+*bank_locator* - keyword, text.text
+
+* _memory_devices.bank_locator_ - String number of the string that identifies the physically-labeled bank where the memory device is located
+
+*base64* - keyword, number.long
+
+* _extended_attributes.base64_ - 1 if the value is base64 encoded else 0
+
+*base_image* - keyword, text.text
+
+* _lxd_instances.base_image_ - ID of image used to launch this instance
+
+*base_uri* - keyword, text.text
+
+* _apt_sources.base_uri_ - Repository base URI
+
+*baseurl* - keyword, text.text
+
+* _yum_sources.baseurl_ - Repository base URL
+
+*basic_constraint* - keyword, text.text
+
+* _curl_certificate.basic_constraint_ - Basic Constraints
+
+*binary_queue* - keyword, number.long
+
+* _carbon_black_info.binary_queue_ - Size in bytes of binaries waiting to be sent to Carbon Black server
+
+*bitmap_chunk_size* - keyword, text.text
+
+* _md_devices.bitmap_chunk_size_ - Bitmap chunk size
+
+*bitmap_external_file* - keyword, text.text
+
+* _md_devices.bitmap_external_file_ - External referenced bitmap file
+
+*bitmap_on_mem* - keyword, text.text
+
+* _md_devices.bitmap_on_mem_ - Pages allocated in in-memory bitmap, if enabled
+
+*block* - keyword, text.text
+
+* _ssh_configs.block_ - The host or match block
+
+*block_size* - keyword, number.long
+
+* _block_devices.block_size_ - Block size in bytes
+* _device_file.block_size_ - Block size of filesystem
+* _file.block_size_ - Block size of filesystem
+
+*blocks* - keyword, number.long
+
+* _device_partitions.blocks_ - Number of blocks
+* _mounts.blocks_ - Mounted device used blocks
+
+*blocks_available* - keyword, number.long
+
+* _mounts.blocks_available_ - Mounted device available blocks
+
+*blocks_free* - keyword, number.long
+
+* _mounts.blocks_free_ - Mounted device free blocks
+
+*blocks_size* - keyword, number.long
+
+* _device_partitions.blocks_size_ - Byte size of each block
+* _mounts.blocks_size_ - Block size in bytes
+
+*bluetooth_sharing* - keyword, number.long
+
+* _sharing_preferences.bluetooth_sharing_ - 1 If bluetooth sharing is enabled for any user else 0
+
+*board_model* - keyword, text.text
+
+* _system_info.board_model_ - Board model
+
+*board_serial* - keyword, text.text
+
+* _system_info.board_serial_ - Board serial number
+
+*board_vendor* - keyword, text.text
+
+* _system_info.board_vendor_ - Board vendor
+
+*board_version* - keyword, text.text
+
+* _system_info.board_version_ - Board version
+
+*boot_partition* - keyword, number.long
+
+* _logical_drives.boot_partition_ - True if Windows booted from this drive.
+
+*boot_uuid* - keyword, text.text
+
+* _ibridge_info.boot_uuid_ - Boot UUID of the iBridge controller
+
+*bp_microcode_disabled* - keyword, number.long
+
+* _kva_speculative_info.bp_microcode_disabled_ - Branch Predictions are disabled due to lack of microcode update.
+
+*bp_mitigations* - keyword, number.long
+
+* _kva_speculative_info.bp_mitigations_ - Branch Prediction mitigations are enabled.
+
+*bp_system_pol_disabled* - keyword, number.long
+
+* _kva_speculative_info.bp_system_pol_disabled_ - Branch Predictions are disabled via system policy.
+
+*breach_description* - keyword, text.text
+
+* _chassis_info.breach_description_ - If provided, gives a more detailed description of a detected security breach.
+
+*bridge_nf_ip6tables* - keyword, number.long
+
+* _docker_info.bridge_nf_ip6tables_ - 1 if bridge netfilter ip6tables is enabled. 0 otherwise
+
+*bridge_nf_iptables* - keyword, number.long
+
+* _docker_info.bridge_nf_iptables_ - 1 if bridge netfilter iptables is enabled. 0 otherwise
+
+*broadcast* - keyword, text.text
+
+* _interface_addresses.broadcast_ - Broadcast address for the interface
+
+*browser_type* - keyword, text.text
+
+* _chrome_extension_content_scripts.browser_type_ - The browser type (Valid values: chrome, chromium, opera, yandex, brave)
+* _chrome_extensions.browser_type_ - The browser type (Valid values: chrome, chromium, opera, yandex, brave, edge, edge_beta)
+
+*bsd_flags* - keyword, text.text
+
+* _file.bsd_flags_ - The BSD file flags (chflags). Possible values: NODUMP, UF_IMMUTABLE, UF_APPEND, OPAQUE, HIDDEN, ARCHIVED, SF_IMMUTABLE, SF_APPEND
+
+*bssid* - keyword, text.text
+
+* _wifi_status.bssid_ - The current basic service set identifier
+* _wifi_survey.bssid_ - The current basic service set identifier
+
+*btime* - keyword, number.long
+
+* _file.btime_ - (B)irth or (cr)eate time
+* _process_events.btime_ - File creation in UNIX time
+
+*buffers* - keyword, number.long
+
+* _memory_info.buffers_ - The amount of physical RAM, in bytes, used for file buffers
+
+*build* - keyword, text.text
+
+* _os_version.build_ - Optional build-specific or variant string
+
+*build_distro* - keyword, text.text
+
+* _osquery_info.build_distro_ - osquery toolkit platform distribution name (os version)
+
+*build_id* - keyword, text.text
+
+* _sandboxes.build_id_ - Sandbox-specific identifier
+
+*build_number* - keyword, number.long
+
+* _windows_crashes.build_number_ - Windows build number of the crashing machine
+
+*build_platform* - keyword, text.text
+
+* _osquery_info.build_platform_ - osquery toolkit build platform
+
+*build_time* - keyword, text.text
+
+* _docker_version.build_time_ - Build time
+* _portage_packages.build_time_ - Unix time when package was built
+
+*bundle_executable* - keyword, text.text
+
+* _apps.bundle_executable_ - Info properties CFBundleExecutable label
+
+*bundle_identifier* - keyword, text.text
+
+* _apps.bundle_identifier_ - Info properties CFBundleIdentifier label
+* _running_apps.bundle_identifier_ - The bundle identifier of the application
+
+*bundle_name* - keyword, text.text
+
+* _apps.bundle_name_ - Info properties CFBundleName label
+
+*bundle_package_type* - keyword, text.text
+
+* _apps.bundle_package_type_ - Info properties CFBundlePackageType label
+
+*bundle_path* - keyword, text.text
+
+* _sandboxes.bundle_path_ - Application bundle used by the sandbox
+* _system_extensions.bundle_path_ - System extension bundle path
+
+*bundle_short_version* - keyword, text.text
+
+* _apps.bundle_short_version_ - Info properties CFBundleShortVersionString label
+
+*bundle_version* - keyword, text.text
+
+* _apps.bundle_version_ - Info properties CFBundleVersion label
+* _safari_extensions.bundle_version_ - The version of the build that identifies an iteration of the bundle
+
+*busy_state* - keyword, number.long
+
+* _iokit_devicetree.busy_state_ - 1 if the device is in a busy state else 0
+* _iokit_registry.busy_state_ - 1 if the node is in a busy state else 0
+
+*bytes* - keyword, number.long
+
+* _curl.bytes_ - Number of bytes in the response
+* _iptables.bytes_ - Number of matching bytes for this rule.
+
+*bytes_available* - keyword, number.long
+
+* _time_machine_destinations.bytes_available_ - Bytes available on volume
+
+*bytes_received* - keyword, number.long
+
+* _lxd_networks.bytes_received_ - Number of bytes received on this network
+
+*bytes_sent* - keyword, number.long
+
+* _lxd_networks.bytes_sent_ - Number of bytes sent on this network
+
+*bytes_used* - keyword, number.long
+
+* _time_machine_destinations.bytes_used_ - Bytes used on volume
+
+*ca* - keyword, number.long
+
+* _certificates.ca_ - 1 if CA: true (certificate is an authority) else 0
+
+*cache_path* - keyword, text.text
+
+* _quicklook_cache.cache_path_ - Path to cache data
+
+*cached* - keyword, number.long
+
+* _lxd_images.cached_ - Whether image is cached (1) or not (0)
+* _memory_info.cached_ - The amount of physical RAM, in bytes, used as cache memory
+
+*capability* - keyword, number.long
+
+* _apparmor_events.capability_ - Capability number
+
+*capname* - keyword, text.text
+
+* _apparmor_events.capname_ - Capability requested by the process
+
+*caption* - keyword, text.text
+
+* _patches.caption_ - Short description of the patch.
+* _windows_optional_features.caption_ - Caption of feature in settings UI
+
+*captive_login_date* - keyword, number.long
+
+* _wifi_networks.captive_login_date_ - Time this network logged in to a captive portal as unix_time
+
+*captive_portal* - keyword, number.long
+
+* _wifi_networks.captive_portal_ - 1 if this network has a captive portal, 0 otherwise
+
+*carve* - keyword, number.long
+
+* _carves.carve_ - Set this value to '1' to start a file carve
+
+*carve_guid* - keyword, text.text
+
+* _carves.carve_guid_ - Identifying value of the carve session
+
+*category* - keyword, text.text
+
+* _apps.category_ - The UTI that categorizes the app for the App Store
+* _file_events.category_ - The category of the file defined in the config
+* _ntfs_journal_events.category_ - The category that the event originated from
+* _power_sensors.category_ - The sensor category: currents, voltage, wattage
+* _system_extensions.category_ - System extension category
+* _unified_log.category_ - the category of the os_log_t used
+* _yara_events.category_ - The category of the file
+
+*cdhash* - keyword, text.text
+
+* _es_process_events.cdhash_ - Codesigning hash of the process
+* _signature.cdhash_ - Hash of the application Code Directory
+
+*celsius* - keyword, number.double
+
+* _temperature_sensors.celsius_ - Temperature in Celsius
+
+*certificate* - keyword, text.text
+
+* _lxd_certificates.certificate_ - Certificate content
+
+*cgroup_driver* - keyword, text.text
+
+* _docker_info.cgroup_driver_ - Control groups driver
+
+*cgroup_namespace* - keyword, text.text
+
+* _docker_containers.cgroup_namespace_ - cgroup namespace
+* _process_namespaces.cgroup_namespace_ - cgroup namespace inode
+
+*cgroup_path* - keyword, text.text
+
+* _processes.cgroup_path_ - The full hierarchical path of the process's control group
+
+*chain* - keyword, text.text
+
+* _iptables.chain_ - Size of module content.
+
+*change_type* - keyword, text.text
+
+* _docker_container_fs_changes.change_type_ - Type of change: C:Modified, A:Added, D:Deleted
+
+*channel* - keyword
+
+* _wifi_status.channel_ - Channel number
+* _wifi_survey.channel_ - Channel number
+* _windows_eventlog.channel_ - Source or channel of the event
+
+*channel_band* - keyword, number.long
+
+* _wifi_status.channel_band_ - Channel band
+* _wifi_survey.channel_band_ - Channel band
+
+*channel_width* - keyword, number.long
+
+* _wifi_status.channel_width_ - Channel width
+* _wifi_survey.channel_width_ - Channel width
+
+*charged* - keyword, number.long
+
+* _battery.charged_ - 1 if the battery is currently completely charged. 0 otherwise
+
+*charging* - keyword, number.long
+
+* _battery.charging_ - 1 if the battery is currently being charged by a power source. 0 otherwise
+
+*chassis_types* - keyword, text.text
+
+* _chassis_info.chassis_types_ - A comma-separated list of chassis types, such as Desktop or Laptop.
+
+*check_array_finish* - keyword, text.text
+
+* _md_devices.check_array_finish_ - Estimated duration of the check array activity
+
+*check_array_progress* - keyword, text.text
+
+* _md_devices.check_array_progress_ - Progress of the check array activity
+
+*check_array_speed* - keyword, text.text
+
+* _md_devices.check_array_speed_ - Speed of the check array activity
+
+*checksum* - keyword, text.text
+
+* _disk_events.checksum_ - UDIF Master checksum if available (CRC32)
+
+*chemistry* - keyword, text.text
+
+* _battery.chemistry_ - The battery chemistry type (eg. LiP). Some possible values are documented in https://learn.microsoft.com/en-us/windows/win32/power/battery-information-str.
+
+*child_pid* - keyword, number.long
+
+* _es_process_events.child_pid_ - Process ID of a child process in case of a fork event
+
+*chunk_size* - keyword, number.long
+
+* _md_devices.chunk_size_ - chunk size in bytes
+
+*cid* - keyword, number.long
+
+* _bpf_process_events.cid_ - Cgroup ID
+* _bpf_socket_events.cid_ - Cgroup ID
+
+*class* - keyword, text.text
+
+* _authorizations.class_ - Label top-level key
+* _drivers.class_ - Device/driver class name
+* _iokit_devicetree.class_ - Best matching device class (most-specific category)
+* _iokit_registry.class_ - Best matching device class (most-specific category)
+* _usb_devices.class_ - USB Device class
+* _wmi_cli_event_consumers.class_ - The name of the class.
+* _wmi_event_filters.class_ - The name of the class.
+* _wmi_filter_consumer_binding.class_ - The name of the class.
+* _wmi_script_event_consumers.class_ - The name of the class.
+
+*clear_text_password* - keyword, number.long
+
+* _security_profile_info.clear_text_password_ - Determines whether passwords MUST be stored by using reversible encryption
+
+*client_app_id* - keyword, text.text
+
+* _windows_update_history.client_app_id_ - Identifier of the client application that processed an update
+
+*client_site_name* - keyword, text.text
+
+* _ntdomains.client_site_name_ - The name of the site where the domain controller is configured.
+
+*cloud_id* - keyword, text.text
+
+* _ycloud_instance_metadata.cloud_id_ - Cloud identifier for the VM
+
+*cmdline* - keyword, text.text
+
+* _bpf_process_events.cmdline_ - Command line arguments
+* _docker_container_processes.cmdline_ - Complete argv
+* _es_process_events.cmdline_ - Command line arguments (argv)
+* _process_etw_events.cmdline_ - Command Line
+* _process_events.cmdline_ - Command line arguments (argv)
+* _processes.cmdline_ - Complete argv
+
+*cmdline_count* - keyword, number.long
+
+* _es_process_events.cmdline_count_ - Number of command line arguments
+
+*cmdline_size* - keyword, number.long
+
+* _process_events.cmdline_size_ - Actual size (bytes) of command line arguments
+
+*code* - keyword, text.text
+
+* _seccomp_events.code_ - The seccomp action
+
+*code_integrity_policy_enforcement_status* - keyword, text.text
+
+* _deviceguard_status.code_integrity_policy_enforcement_status_ - The status of the code integrity policy enforcement settings. Returns UNKNOWN if an error is encountered.
+
+*codename* - keyword, text.text
+
+* _os_version.codename_ - OS version codename
+
+*codesigning_flags* - keyword, text.text
+
+* _es_process_events.codesigning_flags_ - Codesigning flags matching one of these options, in a comma separated list: NOT_VALID, ADHOC, NOT_RUNTIME, INSTALLER. See kern/cs_blobs.h in XNU for descriptions.
+
+*collect_cross_processes* - keyword, number.long
+
+* _carbon_black_info.collect_cross_processes_ - If the sensor is configured to cross process events
+
+*collect_data_file_writes* - keyword, number.long
+
+* _carbon_black_info.collect_data_file_writes_ - If the sensor is configured to collect non binary file writes
+
+*collect_emet_events* - keyword, number.long
+
+* _carbon_black_info.collect_emet_events_ - If the sensor is configured to EMET events
+
+*collect_file_mods* - keyword, number.long
+
+* _carbon_black_info.collect_file_mods_ - If the sensor is configured to collect file modification events
+
+*collect_module_info* - keyword, number.long
+
+* _carbon_black_info.collect_module_info_ - If the sensor is configured to collect metadata of binaries
+
+*collect_module_loads* - keyword, number.long
+
+* _carbon_black_info.collect_module_loads_ - If the sensor is configured to capture module loads
+
+*collect_net_conns* - keyword, number.long
+
+* _carbon_black_info.collect_net_conns_ - If the sensor is configured to collect network connections
+
+*collect_process_user_context* - keyword, number.long
+
+* _carbon_black_info.collect_process_user_context_ - If the sensor is configured to collect the user running a process
+
+*collect_processes* - keyword, number.long
+
+* _carbon_black_info.collect_processes_ - If the sensor is configured to process events
+
+*collect_reg_mods* - keyword, number.long
+
+* _carbon_black_info.collect_reg_mods_ - If the sensor is configured to collect registry modification events
+
+*collect_sensor_operations* - keyword, number.long
+
+* _carbon_black_info.collect_sensor_operations_ - Unknown
+
+*collect_store_files* - keyword, number.long
+
+* _carbon_black_info.collect_store_files_ - If the sensor is configured to send back binaries to the Carbon Black server
+
+*collisions* - keyword, number.long
+
+* _interface_details.collisions_ - Packet Collisions detected
+
+*color_depth* - keyword, number.long
+
+* _video_info.color_depth_ - The amount of bits per pixel to represent color.
+
+*comm* - keyword, text.text
+
+* _apparmor_events.comm_ - Command-line name of the command that was used to invoke the analyzed process
+* _seccomp_events.comm_ - Command-line name of the command that was used to invoke the analyzed process
+
+*command* - keyword, text.text
+
+* _crontab.command_ - Raw command string
+* _docker_containers.command_ - Command with arguments
+* _shell_history.command_ - Unparsed date/line/command history line
+
+*command_line* - keyword, text.text
+
+* _windows_crashes.command_line_ - Command-line string passed to the crashed process
+
+*command_line_template* - keyword, text.text
+
+* _wmi_cli_event_consumers.command_line_template_ - Standard string template that specifies the process to be started. This property can be NULL, and the ExecutablePath property is used as the command line.
+
+*comment* - keyword, text.text
+
+* _authorizations.comment_ - Label top-level key
+* _authorized_keys.comment_ - Optional comment
+* _docker_image_history.comment_ - Instruction comment
+* _etc_protocols.comment_ - Comment with protocol description
+* _etc_services.comment_ - Optional comment for a service.
+* _groups.comment_ - Remarks or comments associated with the group
+* _keychain_items.comment_ - Optional keychain comment
+
+*common_name* - keyword, text.text
+
+* _certificates.common_name_ - Certificate CommonName
+* _curl_certificate.common_name_ - Common name of company issued to
+
+*compat* - keyword, number.long
+
+* _seccomp_events.compat_ - Is system call in compatibility mode
+
+*compiler* - keyword, text.text
+
+* _apps.compiler_ - Info properties DTCompiler label
+
+*completed_time* - keyword, number.long
+
+* _cups_jobs.completed_time_ - When the job completed printing
+
+*components* - keyword, text.text
+
+* _apt_sources.components_ - Repository components
+
+*compressed* - keyword, number.long
+
+* _virtual_memory_info.compressed_ - The total number of pages that have been compressed by the VM compressor.
+
+*compressor* - keyword, number.long
+
+* _virtual_memory_info.compressor_ - The number of pages used to store compressed VM pages.
+
+*computer_name* - keyword, text.text
+
+* _system_info.computer_name_ - Friendly computer name (optional)
+* _windows_eventlog.computer_name_ - Hostname of system where event was generated
+* _windows_events.computer_name_ - Hostname of system where event was generated
+
+*condition* - keyword, text.text
+
+* _battery.condition_ - One of the following: "Normal" indicates the condition of the battery is within normal tolerances, "Service Needed" indicates that the battery should be checked out by a licensed Mac repair service, "Permanent Failure" indicates the battery needs replacement
+
+*config_entrypoint* - keyword, text.text
+
+* _docker_containers.config_entrypoint_ - Container entrypoint(s)
+
+*config_flag* - keyword, text.text
+
+* _sip_config.config_flag_ - The System Integrity Protection config flag
+
+*config_hash* - keyword, text.text
+
+* _osquery_info.config_hash_ - Hash of the working configuration state
+
+*config_name* - keyword, text.text
+
+* _carbon_black_info.config_name_ - Sensor group
+
+*config_valid* - keyword, number.long
+
+* _osquery_info.config_valid_ - 1 if the config was loaded and considered valid, else 0
+
+*config_value* - keyword, text.text
+
+* _system_controls.config_value_ - The MIB value set in /etc/sysctl.conf
+
+*configured_clock_speed* - keyword, number.long
+
+* _memory_devices.configured_clock_speed_ - Configured speed of memory device in megatransfers per second (MT/s)
+
+*configured_security_services* - keyword, text.text
+
+* _deviceguard_status.configured_security_services_ - The list of configured Device Guard services. Returns UNKNOWN if an error is encountered.
+
+*configured_voltage* - keyword, number.long
+
+* _memory_devices.configured_voltage_ - Configured operating voltage of device in millivolts
+
+*connection_id* - keyword, text.text
+
+* _interface_details.connection_id_ - Name of the network connection as it appears in the Network Connections Control Panel program.
+
+*connection_status* - keyword, text.text
+
+* _interface_details.connection_status_ - State of the network adapter connection to the network.
+
+*connection_type* - keyword, text.text
+
+* _connected_displays.connection_type_ - The connection type associated with the display.
+
+*consistency_scan_date* - keyword, number.long
+
+* _time_machine_destinations.consistency_scan_date_ - Consistency scan date
+
+*consumer* - keyword, text.text
+
+* _wmi_filter_consumer_binding.consumer_ - Reference to an instance of __EventConsumer that represents the object path to a logical consumer, the recipient of an event.
+
+*containers* - keyword, number.long
+
+* _docker_info.containers_ - Total number of containers
+
+*containers_paused* - keyword, number.long
+
+* _docker_info.containers_paused_ - Number of containers in paused state
+
+*containers_running* - keyword, number.long
+
+* _docker_info.containers_running_ - Number of containers currently running
+
+*containers_stopped* - keyword, number.long
+
+* _docker_info.containers_stopped_ - Number of containers in stopped state
+
+*content* - keyword, text.text
+
+* _disk_events.content_ - Disk event content
+
+*content_caching* - keyword, number.long
+
+* _sharing_preferences.content_caching_ - 1 If content caching is enabled else 0
+
+*content_type* - keyword, text.text
+
+* _package_install_history.content_type_ - Package content_type (optional)
+
+*conversion_status* - keyword, number.long
+
+* _bitlocker_info.conversion_status_ - The bitlocker conversion status of the drive.
+
+*coprocessor_version* - keyword, text.text
+
+* _ibridge_info.coprocessor_version_ - The manufacturer and chip version
+
+*copy* - keyword, number.long
+
+* _virtual_memory_info.copy_ - Total number of copy-on-write pages.
+
+*copyright* - keyword, text.text
+
+* _apps.copyright_ - Info properties NSHumanReadableCopyright label
+* _safari_extensions.copyright_ - A human-readable copyright notice for the bundle
+
+*core* - keyword, number.long
+
+* _cpu_time.core_ - Name of the cpu (core)
+
+*cosine_similarity* - keyword, number.double
+
+* _powershell_events.cosine_similarity_ - How similar the Powershell script is to a provided 'normal' character frequency
+
+*count* - keyword, number.long
+
+* _userassist.count_ - Number of times the application has been executed.
+* _yara.count_ - Number of YARA matches
+* _yara_events.count_ - Number of YARA matches
+
+*country_code* - keyword, text.text
+
+* _wifi_status.country_code_ - The country code (ISO/IEC 3166-1:1997) for the network
+* _wifi_survey.country_code_ - The country code (ISO/IEC 3166-1:1997) for the network
+
+*cpu* - keyword, number.double
+
+* _docker_container_processes.cpu_ - CPU utilization as percentage
+
+*cpu_brand* - keyword, text.text
+
+* _system_info.cpu_brand_ - CPU brand string, contains vendor and model
+
+*cpu_cfs_period* - keyword, number.long
+
+* _docker_info.cpu_cfs_period_ - 1 if CPU Completely Fair Scheduler (CFS) period support is enabled. 0 otherwise
+
+*cpu_cfs_quota* - keyword, number.long
+
+* _docker_info.cpu_cfs_quota_ - 1 if CPU Completely Fair Scheduler (CFS) quota support is enabled. 0 otherwise
+
+*cpu_kernelmode_usage* - keyword, number.long
+
+* _docker_container_stats.cpu_kernelmode_usage_ - CPU kernel mode usage
+
+*cpu_logical_cores* - keyword, number.long
+
+* _system_info.cpu_logical_cores_ - Number of logical CPU cores available to the system
+
+*cpu_microcode* - keyword, text.text
+
+* _system_info.cpu_microcode_ - Microcode version
+
+*cpu_physical_cores* - keyword, number.long
+
+* _system_info.cpu_physical_cores_ - Number of physical CPU cores in to the system
+
+*cpu_pred_cmd_supported* - keyword, number.long
+
+* _kva_speculative_info.cpu_pred_cmd_supported_ - PRED_CMD MSR supported by CPU Microcode.
+
+*cpu_set* - keyword, number.long
+
+* _docker_info.cpu_set_ - 1 if CPU set selection support is enabled. 0 otherwise
+
+*cpu_shares* - keyword, number.long
+
+* _docker_info.cpu_shares_ - 1 if CPU share weighting support is enabled. 0 otherwise
+
+*cpu_sockets* - keyword, number.long
+
+* _system_info.cpu_sockets_ - Number of processor sockets in the system
+
+*cpu_spec_ctrl_supported* - keyword, number.long
+
+* _kva_speculative_info.cpu_spec_ctrl_supported_ - SPEC_CTRL MSR supported by CPU Microcode.
+
+*cpu_status* - keyword, number.long
+
+* _cpu_info.cpu_status_ - The current operating status of the CPU.
+
+*cpu_subtype* - keyword
+
+* _processes.cpu_subtype_ - Indicates the specific processor on which an entry may be used.
+* _system_info.cpu_subtype_ - CPU subtype
+
+*cpu_total_usage* - keyword, number.long
+
+* _docker_container_stats.cpu_total_usage_ - Total CPU usage
+
+*cpu_type* - keyword
+
+* _processes.cpu_type_ - Indicates the specific processor designed for installation.
+* _system_info.cpu_type_ - CPU type
+
+*cpu_usermode_usage* - keyword, number.long
+
+* _docker_container_stats.cpu_usermode_usage_ - CPU user mode usage
+
+*cpus* - keyword, number.long
+
+* _docker_info.cpus_ - Number of CPUs
+
+*crash_path* - keyword, text.text
+
+* _crashes.crash_path_ - Location of log file
+* _windows_crashes.crash_path_ - Path of the log file
+
+*crashed_thread* - keyword, number.long
+
+* _crashes.crashed_thread_ - Thread ID which crashed
+
+*created* - keyword, text.text
+
+* _authorizations.created_ - Label top-level key
+* _docker_containers.created_ - Time of creation as UNIX time
+* _docker_image_history.created_ - Time of creation as UNIX time
+* _docker_images.created_ - Time of creation as UNIX time
+* _docker_networks.created_ - Time of creation as UNIX time
+* _keychain_items.created_ - Date item was created
+
+*created_at* - keyword, text.text
+
+* _lxd_images.created_at_ - ISO time of image creation
+* _lxd_instances.created_at_ - ISO time of creation
+
+*created_by* - keyword, text.text
+
+* _docker_image_history.created_by_ - Created by instruction
+
+*created_time* - keyword, number.long
+
+* _shellbags.created_time_ - Directory Created time.
+
+*creation_time* - keyword
+
+* _account_policy_data.creation_time_ - When the account was first created
+* _cups_jobs.creation_time_ - When the print request was initiated
+
+*creator* - keyword, text.text
+
+* _firefox_addons.creator_ - Addon-supported creator string
+
+*creator_pid* - keyword, number.long
+
+* _shared_memory.creator_pid_ - Process ID that created the segment
+
+*creator_uid* - keyword, number.long
+
+* _shared_memory.creator_uid_ - User ID of creator process
+
+*csname* - keyword, text.text
+
+* _patches.csname_ - The name of the host the patch is installed on.
+
+*ctime* - keyword
+
+* _device_file.ctime_ - Creation time
+* _file.ctime_ - Last status change time
+* _file_events.ctime_ - Last status change time
+* _gatekeeper_approved_apps.ctime_ - Last change time
+* _process_events.ctime_ - File last metadata change in UNIX time
+* _shared_memory.ctime_ - Changed time
+
+*current_capacity* - keyword, number.long
+
+* _battery.current_capacity_ - The battery's current capacity (level of charge) in mAh
+
+*current_clock_speed* - keyword, number.long
+
+* _cpu_info.current_clock_speed_ - The current frequency of the CPU.
+
+*current_directory* - keyword, text.text
+
+* _windows_crashes.current_directory_ - Current working directory of the crashed process
+
+*current_disk_queue_length* - keyword, number.long
+
+* _physical_disk_performance.current_disk_queue_length_ - Number of requests outstanding on the disk at the time the performance data is collected
+
+*current_locale* - keyword, text.text
+
+* _chrome_extensions.current_locale_ - Current locale supported by extension
+
+*current_value* - keyword, text.text
+
+* _system_controls.current_value_ - Value of setting
+
+*cwd* - keyword, text.text
+
+* _bpf_process_events.cwd_ - Current working directory
+* _es_process_events.cwd_ - The process current working directory
+* _process_events.cwd_ - The process current working directory
+* _process_file_events.cwd_ - The current working directory of the process
+* _processes.cwd_ - Process current working directory
+
+*cycle_count* - keyword, number.long
+
+* _battery.cycle_count_ - The number of charge/discharge cycles
+
+*data* - keyword, text.text
+
+* _magic.data_ - Magic number data from libmagic
+* _registry.data_ - Data content of registry value
+* _windows_eventlog.data_ - Data associated with the event
+* _windows_events.data_ - Data associated with the event
+
+*data_width* - keyword, number.long
+
+* _memory_devices.data_width_ - Data width, in bits, of this memory device
+
+*database* - keyword, number.long
+
+* _lxd_cluster_members.database_ - Whether the server is a database node (1) or not (0)
+
+*date* - keyword
+
+* _drivers.date_ - Driver date
+* _platform_info.date_ - Self-reported platform code update date
+* _windows_update_history.date_ - Date and the time an update was applied
+
+*date_created* - keyword, number.long
+
+* _windows_search.date_created_ - The unix timestamp of when the item was created.
+
+*date_modified* - keyword, number.long
+
+* _windows_search.date_modified_ - The unix timestamp of when the item was last modified
+
+*datetime* - keyword, text.text
+
+* _crashes.datetime_ - Date/Time at which the crash occurred
+* _powershell_events.datetime_ - System time at which the Powershell script event occurred
+* _process_etw_events.datetime_ - Event timestamp in DATETIME format
+* _syslog_events.datetime_ - Time known to syslog
+* _time.datetime_ - Current date and time (ISO format) in UTC
+* _windows_crashes.datetime_ - Timestamp (log format) of the crash
+* _windows_eventlog.datetime_ - System time at which the event occurred
+* _windows_events.datetime_ - System time at which the event occurred
+
+*day* - keyword, number.long
+
+* _time.day_ - Current day in UTC
+
+*day_of_month* - keyword, text.text
+
+* _crontab.day_of_month_ - The day of the month for the job
+
+*day_of_week* - keyword, text.text
+
+* _crontab.day_of_week_ - The day of the week for the job
+
+*days* - keyword, number.long
+
+* _uptime.days_ - Days of uptime
+
+*dc_site_name* - keyword, text.text
+
+* _ntdomains.dc_site_name_ - The name of the site where the domain controller is located.
+
+*decompressed* - keyword, number.long
+
+* _virtual_memory_info.decompressed_ - The total number of pages that have been decompressed by the VM compressor.
+
+*default_locale* - keyword, text.text
+
+* _chrome_extensions.default_locale_ - Default locale supported by extension
+
+*default_value* - keyword, text.text
+
+* _osquery_flags.default_value_ - Flag default value
+
+*denied_mask* - keyword, text.text
+
+* _apparmor_events.denied_mask_ - Denied permissions for the process
+
+*denylisted* - keyword, number.long
+
+* _osquery_schedule.denylisted_ - 1 if the query is denylisted else 0
+
+*dependencies* - keyword, text.text
+
+* _kernel_panics.dependencies_ - Module dependencies existing in crashed module's backtrace
+
+*depth* - keyword, number.long
+
+* _iokit_devicetree.depth_ - Device nested depth
+* _iokit_registry.depth_ - Node nested depth
+
+*description* - keyword, text.text
+
+* _appcompat_shims.description_ - Description of the SDB.
+* _browser_plugins.description_ - Plugin description text
+* _chassis_info.description_ - An extended description of the chassis if available.
+* _chrome_extensions.description_ - Extension-optional description
+* _disk_info.description_ - The OS's description of the disk.
+* _drivers.description_ - Driver description
+* _firefox_addons.description_ - Addon-supplied description string
+* _interface_details.description_ - Short description of the object a one-line string.
+* _kernel_keys.description_ - The key description.
+* _keychain_acls.description_ - The description included with the ACL entry
+* _keychain_items.description_ - Optional item description
+* _logical_drives.description_ - The canonical description of the drive, e.g. 'Logical Fixed Disk', 'CD-ROM Disk'.
+* _lxd_images.description_ - Image description
+* _lxd_instances.description_ - Instance description
+* _npm_packages.description_ - Package-supplied description
+* _osquery_flags.description_ - Flag description
+* _patches.description_ - Fuller description of the patch.
+* _safari_extensions.description_ - Optional extension description text
+* _secureboot.description_ - (Apple Silicon) Human-readable description: 'Full Security', 'Reduced Security', or 'Permissive Security'
+* _services.description_ - Service Description
+* _shared_resources.description_ - A textual description of the object
+* _smbios_tables.description_ - Table entry description
+* _systemd_units.description_ - Unit description
+* _users.description_ - Optional user description
+* _windows_update_history.description_ - Description of an update
+* _ycloud_instance_metadata.description_ - Description of the VM
+
+*designed_capacity* - keyword, number.long
+
+* _battery.designed_capacity_ - The battery's designed capacity in mAh
+
+*dest_filename* - keyword, text.text
+
+* _es_process_file_events.dest_filename_ - Destination filename for the event
+
+*dest_path* - keyword, text.text
+
+* _process_file_events.dest_path_ - The canonical path associated with the event
+
+*destination* - keyword, text.text
+
+* _cups_jobs.destination_ - The printer the job was sent to
+* _docker_container_mounts.destination_ - Destination path inside container
+* _routes.destination_ - Destination IP address
+
+*destination_id* - keyword, text.text
+
+* _time_machine_backups.destination_id_ - Time Machine destination ID
+* _time_machine_destinations.destination_id_ - Time Machine destination ID
+
+*dev_id_enabled* - keyword, number.long
+
+* _gatekeeper.dev_id_enabled_ - 1 If a Gatekeeper allows execution from identified developers else 0
+
+*developer_id* - keyword, text.text
+
+* _xprotect_meta.developer_id_ - Developer identity (SHA1) of extension
+
+*development_region* - keyword, text.text
+
+* _apps.development_region_ - Info properties CFBundleDevelopmentRegion label
+* _browser_plugins.development_region_ - Plugin language-localization
+
+*device* - keyword, text.text
+
+* _device_file.device_ - Absolute file path to device node
+* _device_firmware.device_ - The device name
+* _device_hash.device_ - Absolute file path to device node
+* _device_partitions.device_ - Absolute file path to device node
+* _disk_events.device_ - Disk event BSD name
+* _file.device_ - Device ID (optional)
+* _kernel_info.device_ - Kernel device identifier
+* _lxd_instance_devices.device_ - Name of the device
+* _mounts.device_ - Mounted device
+* _process_memory_map.device_ - MA:MI Major/minor device ID
+
+*device_alias* - keyword, text.text
+
+* _mounts.device_alias_ - Mounted device alias
+
+*device_error_address* - keyword, text.text
+
+* _memory_error_info.device_error_address_ - 32 bit physical address of the error relative to the start of the failing memory address, in bytes
+
+*device_id* - keyword, text.text
+
+* _bitlocker_info.device_id_ - ID of the encrypted drive.
+* _cpu_info.device_id_ - The DeviceID of the CPU.
+* _drivers.device_id_ - Device ID
+* _logical_drives.device_id_ - The drive id, usually the drive name, e.g., 'C:'.
+
+*device_locator* - keyword, text.text
+
+* _memory_devices.device_locator_ - String number of the string that identifies the physically-labeled socket or board position where the memory device is located
+
+*device_name* - keyword, text.text
+
+* _drivers.device_name_ - Device name
+* _md_devices.device_name_ - md device name
+
+*device_path* - keyword, text.text
+
+* _iokit_devicetree.device_path_ - Device tree path
+
+*device_type* - keyword, text.text
+
+* _lxd_instance_devices.device_type_ - Device type
+
+*dhcp_enabled* - keyword, number.long
+
+* _interface_details.dhcp_enabled_ - If TRUE, the dynamic host configuration protocol (DHCP) server automatically assigns an IP address to the computer system when establishing a network connection.
+
+*dhcp_lease_expires* - keyword, text.text
+
+* _interface_details.dhcp_lease_expires_ - Expiration date and time for a leased IP address that was assigned to the computer by the dynamic host configuration protocol (DHCP) server.
+
+*dhcp_lease_obtained* - keyword, text.text
+
+* _interface_details.dhcp_lease_obtained_ - Date and time the lease was obtained for the IP address assigned to the computer by the dynamic host configuration protocol (DHCP) server.
+
+*dhcp_server* - keyword, text.text
+
+* _interface_details.dhcp_server_ - IP address of the dynamic host configuration protocol (DHCP) server.
+
+*direction* - keyword, text.text
+
+* _windows_firewall_rules.direction_ - Direction of traffic for which the rule applies
+
+*directory* - keyword, text.text
+
+* _extended_attributes.directory_ - Directory of file(s)
+* _file.directory_ - Directory of file(s)
+* _hash.directory_ - Must provide a path or directory
+* _npm_packages.directory_ - Directory where node_modules are located
+* _python_packages.directory_ - Directory where Python modules are located
+* _users.directory_ - User's home directory
+
+*disabled* - keyword
+
+* _browser_plugins.disabled_ - Is the plugin disabled. 1 = Disabled
+* _firefox_addons.disabled_ - 1 If the addon is application-disabled else 0
+* _launchd.disabled_ - Skip loading this daemon or agent on boot
+* _wifi_networks.disabled_ - 1 if this network is disabled, 0 otherwise
+
+*disc_sharing* - keyword, number.long
+
+* _sharing_preferences.disc_sharing_ - 1 If CD or DVD sharing is enabled else 0
+
+*disconnected* - keyword, number.long
+
+* _connectivity.disconnected_ - True if the all interfaces are not connected to any network
+
+*discovery_cache_hits* - keyword, number.long
+
+* _osquery_packs.discovery_cache_hits_ - The number of times that the discovery query used cached values since the last time the config was reloaded
+
+*discovery_executions* - keyword, number.long
+
+* _osquery_packs.discovery_executions_ - The number of times that the discovery queries have been executed since the last time the config was reloaded
+
+*disk_bytes_read* - keyword, number.long
+
+* _processes.disk_bytes_read_ - Bytes read from disk
+
+*disk_bytes_written* - keyword, number.long
+
+* _processes.disk_bytes_written_ - Bytes written to disk
+
+*disk_index* - keyword, number.long
+
+* _disk_info.disk_index_ - Physical drive number of the disk.
+
+*disk_read* - keyword, number.long
+
+* _docker_container_stats.disk_read_ - Total disk read bytes
+
+*disk_size* - keyword, number.long
+
+* _disk_info.disk_size_ - Size of the disk.
+
+*disk_write* - keyword, number.long
+
+* _docker_container_stats.disk_write_ - Total disk write bytes
+
+*display_id* - keyword, text.text
+
+* _connected_displays.display_id_ - The display ID.
+
+*display_name* - keyword, text.text
+
+* _apps.display_name_ - Info properties CFBundleDisplayName label
+* _services.display_name_ - Service Display name
+
+*display_type* - keyword, text.text
+
+* _connected_displays.display_type_ - The type of display.
+
+*dns_domain* - keyword, text.text
+
+* _interface_details.dns_domain_ - Organization name followed by a period and an extension that indicates the type of organization, such as 'microsoft.com'.
+
+*dns_domain_name* - keyword, text.text
+
+* _logon_sessions.dns_domain_name_ - The DNS name for the owner of the logon session.
+
+*dns_domain_suffix_search_order* - keyword, text.text
+
+* _interface_details.dns_domain_suffix_search_order_ - Array of DNS domain suffixes to be appended to the end of host names during name resolution.
+
+*dns_forest_name* - keyword, text.text
+
+* _ntdomains.dns_forest_name_ - The name of the root of the DNS tree.
+
+*dns_host_name* - keyword, text.text
+
+* _interface_details.dns_host_name_ - Host name used to identify the local computer for authentication by some utilities.
+
+*dns_server_search_order* - keyword, text.text
+
+* _interface_details.dns_server_search_order_ - Array of server IP addresses to be used in querying for DNS servers.
+
+*domain* - keyword, text.text
+
+* _ad_config.domain_ - Active Directory trust domain
+* _managed_policies.domain_ - System or manager-chosen domain key
+* _preferences.domain_ - Application ID usually in com.name.product format
+
+*domain_controller_address* - keyword, text.text
+
+* _ntdomains.domain_controller_address_ - The IP Address of the discovered domain controller..
+
+*domain_controller_name* - keyword, text.text
+
+* _ntdomains.domain_controller_name_ - The name of the discovered domain controller.
+
+*domain_name* - keyword, text.text
+
+* _ntdomains.domain_name_ - The name of the domain.
+
+*drive_letter* - keyword, text.text
+
+* _bitlocker_info.drive_letter_ - Drive letter of the encrypted drive.
+* _ntfs_journal_events.drive_letter_ - The drive letter identifying the source journal
+
+*drive_name* - keyword, text.text
+
+* _md_drives.drive_name_ - Drive device name
+
+*driver* - keyword, text.text
+
+* _docker_container_mounts.driver_ - Driver providing the mount
+* _docker_networks.driver_ - Network driver
+* _docker_volumes.driver_ - Volume driver
+* _hardware_events.driver_ - Driver claiming the device
+* _lxd_storage_pools.driver_ - Storage driver
+* _pci_devices.driver_ - PCI Device used driver
+* _video_info.driver_ - The driver of the device.
+
+*driver_date* - keyword, number.long
+
+* _video_info.driver_date_ - The date listed on the installed driver.
+
+*driver_key* - keyword, text.text
+
+* _drivers.driver_key_ - Driver key
+
+*driver_version* - keyword, text.text
+
+* _video_info.driver_version_ - The version of the installed driver.
+
+*dst_ip* - keyword, text.text
+
+* _iptables.dst_ip_ - Destination IP address.
+
+*dst_mask* - keyword, text.text
+
+* _iptables.dst_mask_ - Destination IP address mask.
+
+*dst_port* - keyword, text.text
+
+* _iptables.dst_port_ - Protocol destination port(s).
+
+*dtime* - keyword, number.long
+
+* _shared_memory.dtime_ - Detached time
+
+*dump_certificate* - keyword, number.long
+
+* _curl_certificate.dump_certificate_ - Set this value to '1' to dump certificate
+
+*duration* - keyword, number.long
+
+* _bpf_process_events.duration_ - How much time was spent inside the syscall (nsecs)
+* _bpf_socket_events.duration_ - How much time was spent inside the syscall (nsecs)
+
+*eapi* - keyword, number.long
+
+* _portage_packages.eapi_ - The eapi for the ebuild
+
+*egid* - keyword
+
+* _docker_container_processes.egid_ - Effective group ID
+* _es_process_events.egid_ - Effective Group ID of the process
+* _process_events.egid_ - Effective group ID at process start
+* _process_file_events.egid_ - Effective group ID of the process using the file
+* _processes.egid_ - Unsigned effective group ID
+
+*eid* - keyword, text.text
+
+* _apparmor_events.eid_ - Event ID
+* _bpf_process_events.eid_ - Event ID
+* _bpf_socket_events.eid_ - Event ID
+* _disk_events.eid_ - Event ID
+* _es_process_events.eid_ - Event ID
+* _es_process_file_events.eid_ - Event ID
+* _file_events.eid_ - Event ID
+* _hardware_events.eid_ - Event ID
+* _ntfs_journal_events.eid_ - Event ID
+* _process_etw_events.eid_ - Event ID
+* _process_events.eid_ - Event ID
+* _process_file_events.eid_ - Event ID
+* _selinux_events.eid_ - Event ID
+* _socket_events.eid_ - Event ID
+* _syslog_events.eid_ - Event ID
+* _user_events.eid_ - Event ID
+* _windows_events.eid_ - Event ID
+* _yara_events.eid_ - Event ID
+
+*ejectable* - keyword, number.long
+
+* _disk_events.ejectable_ - 1 if ejectable, 0 if not
+
+*elapsed_time* - keyword, number.long
+
+* _processes.elapsed_time_ - Elapsed time in seconds this process has been running.
+
+*element* - keyword, text.text
+
+* _apps.element_ - Does the app identify as a background agent
+
+*elevated_token* - keyword, number.long
+
+* _processes.elevated_token_ - Process uses elevated token yes=1, no=0
+
+*enable_admin_account* - keyword, number.long
+
+* _security_profile_info.enable_admin_account_ - Determines whether the Administrator account on the local computer is enabled
+
+*enable_guest_account* - keyword, number.long
+
+* _security_profile_info.enable_guest_account_ - Determines whether the Guest account on the local computer is enabled
+
+*enable_ipv6* - keyword, number.long
+
+* _docker_networks.enable_ipv6_ - 1 if IPv6 is enabled on this network. 0 otherwise
+
+*enabled* - keyword
+
+* _app_schemes.enabled_ - 1 if this handler is the OS default, else 0
+* _event_taps.enabled_ - Is the Event Tap enabled
+* _interface_details.enabled_ - Indicates whether the adapter is enabled or not.
+* _location_services.enabled_ - 1 if Location Services are enabled, else 0
+* _lxd_cluster.enabled_ - Whether clustering enabled (1) or not (0) on this node
+* _sandboxes.enabled_ - Application sandboxings enabled on container
+* _scheduled_tasks.enabled_ - Whether or not the scheduled task is enabled
+* _screenlock.enabled_ - 1 If a password is required after sleep or the screensaver begins; else 0
+* _sip_config.enabled_ - 1 if this configuration is enabled, otherwise 0
+* _tpm_info.enabled_ - TPM is enabled
+* _windows_firewall_rules.enabled_ - 1 if the rule is enabled
+* _yum_sources.enabled_ - Whether the repository is used
+
+*enabled_nvram* - keyword, number.long
+
+* _sip_config.enabled_nvram_ - 1 if this configuration is enabled, otherwise 0
+
+*encrypted* - keyword, number.long
+
+* _disk_encryption.encrypted_ - 1 If encrypted: true (disk is encrypted), else 0
+* _user_ssh_keys.encrypted_ - 1 if key is encrypted, 0 otherwise
+
+*encryption* - keyword, text.text
+
+* _time_machine_destinations.encryption_ - Last known encrypted state
+
+*encryption_method* - keyword, text.text
+
+* _bitlocker_info.encryption_method_ - The encryption type of the device.
+
+*encryption_status* - keyword, text.text
+
+* _disk_encryption.encryption_status_ - Disk encryption status with one of following values: encrypted | not encrypted | undefined
+
+*end* - keyword, text.text
+
+* _memory_map.end_ - End address of memory region
+* _process_memory_map.end_ - Virtual end address (hex)
+
+*ending_address* - keyword, text.text
+
+* _memory_array_mapped_addresses.ending_address_ - Physical ending address of last kilobyte of a range of memory mapped to physical memory array
+* _memory_device_mapped_addresses.ending_address_ - Physical ending address of last kilobyte of a range of memory mapped to physical memory array
+
+*endpoint_id* - keyword, text.text
+
+* _docker_container_networks.endpoint_id_ - Endpoint ID
+
+*entry* - keyword, text.text
+
+* _authorization_mechanisms.entry_ - The whole string entry
+* _shimcache.entry_ - Execution order.
+
+*env* - keyword, text.text
+
+* _es_process_events.env_ - Environment variables delimited by spaces
+* _process_events.env_ - Environment variables delimited by spaces
+
+*env_count* - keyword, number.long
+
+* _es_process_events.env_count_ - Number of environment variables
+* _process_events.env_count_ - Number of environment variables
+
+*env_size* - keyword, number.long
+
+* _process_events.env_size_ - Actual size (bytes) of environment list
+
+*env_variables* - keyword, text.text
+
+* _docker_containers.env_variables_ - Container environmental variables
+
+*environment* - keyword, text.text
+
+* _apps.environment_ - Application-set environment variables
+
+*ephemeral* - keyword, number.long
+
+* _lxd_instances.ephemeral_ - Whether the instance is ephemeral(1) or not(0)
+
+*epoch* - keyword, number.long
+
+* _rpm_packages.epoch_ - Package epoch value
+
+*error* - keyword, text.text
+
+* _apparmor_events.error_ - Error information
+
+*error_granularity* - keyword, text.text
+
+* _memory_error_info.error_granularity_ - Granularity to which the error can be resolved
+
+*error_operation* - keyword, text.text
+
+* _memory_error_info.error_operation_ - Memory access operation that caused the error
+
+*error_resolution* - keyword, text.text
+
+* _memory_error_info.error_resolution_ - Range, in bytes, within which this error can be determined, when an error address is given
+
+*error_type* - keyword, text.text
+
+* _memory_error_info.error_type_ - type of error associated with current error status for array or device
+
+*euid* - keyword
+
+* _docker_container_processes.euid_ - Effective user ID
+* _es_process_events.euid_ - Effective User ID of the process
+* _process_events.euid_ - Effective user ID at process start
+* _process_file_events.euid_ - Effective user ID of the process using the file
+* _processes.euid_ - Unsigned effective user ID
+
+*event* - keyword, text.text
+
+* _crontab.event_ - The job @event name (rare)
+
+*event_queue* - keyword, number.long
+
+* _carbon_black_info.event_queue_ - Size in bytes of Carbon Black event files on disk
+
+*event_tap_id* - keyword, number.long
+
+* _event_taps.event_tap_id_ - Unique ID for the Tap
+
+*event_tapped* - keyword, text.text
+
+* _event_taps.event_tapped_ - The mask that identifies the set of events to be observed.
+
+*event_type* - keyword, text.text
+
+* _es_process_events.event_type_ - Type of EndpointSecurity event
+* _es_process_file_events.event_type_ - Type of EndpointSecurity event
+
+*eventid* - keyword, number.long
+
+* _windows_eventlog.eventid_ - Event ID of the event
+* _windows_events.eventid_ - Event ID of the event
+
+*events* - keyword, number.long
+
+* _osquery_events.events_ - Number of events emitted or received since osquery started
+
+*exception_address* - keyword, text.text
+
+* _windows_crashes.exception_address_ - Address (in hex) where the exception occurred
+
+*exception_code* - keyword, text.text
+
+* _windows_crashes.exception_code_ - The Windows exception code
+
+*exception_codes* - keyword, text.text
+
+* _crashes.exception_codes_ - Exception codes from the crash
+
+*exception_message* - keyword, text.text
+
+* _windows_crashes.exception_message_ - The NTSTATUS error message associated with the exception code
+
+*exception_notes* - keyword, text.text
+
+* _crashes.exception_notes_ - Exception notes from the crash
+
+*exception_type* - keyword, text.text
+
+* _crashes.exception_type_ - Exception type of the crash
+
+*exe* - keyword, text.text
+
+* _seccomp_events.exe_ - The path to the executable that was used to invoke the analyzed process
+
+*executable* - keyword, text.text
+
+* _appcompat_shims.executable_ - Name of the executable that is being shimmed. This is pulled from the registry.
+* _process_file_events.executable_ - The executable path
+
+*executable_path* - keyword, text.text
+
+* _wmi_cli_event_consumers.executable_path_ - Module to execute. The string can specify the full path and file name of the module to execute, or it can specify a partial name. If a partial name is specified, the current drive and current directory are assumed.
+
+*execution_flag* - keyword, number.long
+
+* _shimcache.execution_flag_ - Boolean Execution flag, 1 for execution, 0 for no execution, -1 for missing (this flag does not exist on Windows 10 and higher).
+
+*executions* - keyword, number.long
+
+* _osquery_schedule.executions_ - Number of times the query was executed
+
+*exit_code* - keyword, text.text
+
+* _bpf_process_events.exit_code_ - Exit code of the system call
+* _bpf_socket_events.exit_code_ - Exit code of the system call
+* _es_process_events.exit_code_ - Exit code of a process in case of an exit event
+* _process_etw_events.exit_code_ - Exit Code - Present only on ProcessStop events
+
+*expand* - keyword, number.long
+
+* _default_environment.expand_ - 1 if the variable needs expanding, 0 otherwise
+
+*expire* - keyword, number.long
+
+* _shadow.expire_ - Number of days since UNIX epoch date until account is disabled
+
+*expires_at* - keyword, text.text
+
+* _lxd_images.expires_at_ - ISO time of image expiration
+
+*extended_key_usage* - keyword, text.text
+
+* _curl_certificate.extended_key_usage_ - Extended usage of key in certificate
+
+*extensions* - keyword, text.text
+
+* _osquery_info.extensions_ - osquery extensions status
+
+*external* - keyword, number.long
+
+* _app_schemes.external_ - 1 if this handler does NOT exist on macOS by default, else 0
+
+*extra* - keyword, text.text
+
+* _asl.extra_ - Extra columns, in JSON format. Queries against this column are performed entirely in SQLite, so do not benefit from efficient querying via asl.h.
+* _os_version.extra_ - Optional extra release specification
+* _platform_info.extra_ - Platform-specific additional information
+
+*facility* - keyword, text.text
+
+* _asl.facility_ - Sender's facility.  Default is 'user'.
+* _syslog_events.facility_ - Syslog facility
+
+*fahrenheit* - keyword, number.double
+
+* _temperature_sensors.fahrenheit_ - Temperature in Fahrenheit
+
+*failed_disks* - keyword, number.long
+
+* _md_devices.failed_disks_ - Number of failed disks in array
+
+*failed_login_count* - keyword, number.long
+
+* _account_policy_data.failed_login_count_ - The number of failed login attempts using an incorrect password. Count resets after a correct password is entered.
+
+*failed_login_timestamp* - keyword, number.double
+
+* _account_policy_data.failed_login_timestamp_ - The time of the last failed login attempt. Resets after a correct password is entered
+
+*family* - keyword, number.long
+
+* _bpf_socket_events.family_ - The Internet protocol family ID
+* _listening_ports.family_ - Network protocol (IPv4, IPv6)
+* _process_open_sockets.family_ - Network protocol (IPv4, IPv6)
+* _socket_events.family_ - The Internet protocol family ID
+
+*fan* - keyword, text.text
+
+* _fan_speed_sensors.fan_ - Fan number
+
+*faults* - keyword, number.long
+
+* _virtual_memory_info.faults_ - Total number of calls to vm_faults.
+
+*fd* - keyword, text.text
+
+* _bpf_socket_events.fd_ - The file description for the process socket
+* _listening_ports.fd_ - Socket file descriptor number
+* _process_open_files.fd_ - Process-specific file descriptor number
+* _process_open_pipes.fd_ - File descriptor
+* _process_open_sockets.fd_ - Socket file descriptor number
+* _socket_events.fd_ - The file description for the process socket
+
+*feature* - keyword, text.text
+
+* _cpuid.feature_ - Present feature flags
+
+*feature_control* - keyword, number.long
+
+* _msr.feature_control_ - Bitfield controlling enabled features.
+
+*field_name* - keyword, text.text
+
+* _system_controls.field_name_ - Specific attribute of opaque type
+
+*file_attributes* - keyword, text.text
+
+* _ntfs_journal_events.file_attributes_ - File attributes
+
+*file_backed* - keyword, number.long
+
+* _virtual_memory_info.file_backed_ - Total number of file backed pages.
+
+*file_id* - keyword, text.text
+
+* _file.file_id_ - file ID
+
+*file_sharing* - keyword, number.long
+
+* _sharing_preferences.file_sharing_ - 1 If file sharing is enabled else 0
+
+*file_system* - keyword, text.text
+
+* _logical_drives.file_system_ - The file system of the drive.
+
+*file_version* - keyword, text.text
+
+* _file.file_version_ - File version
+
+*filename* - keyword, text.text
+
+* _device_file.filename_ - Name portion of file path
+* _es_process_file_events.filename_ - The source or target filename for the event
+* _file.filename_ - Name portion of file path
+* _lxd_images.filename_ - Filename of the image file
+* _prefetch.filename_ - Executable filename.
+* _xprotect_entries.filename_ - Use this file name to match
+
+*filepath* - keyword, text.text
+
+* _package_bom.filepath_ - Package file or directory
+
+*filesystem* - keyword, text.text
+
+* _disk_events.filesystem_ - Filesystem if available
+
+*filetype* - keyword, text.text
+
+* _xprotect_entries.filetype_ - Use this file type to match
+
+*filevault_status* - keyword, text.text
+
+* _disk_encryption.filevault_status_ - FileVault status with one of following values: on | off | unknown
+
+*filter* - keyword, text.text
+
+* _wmi_filter_consumer_binding.filter_ - Reference to an instance of __EventFilter that represents the object path to an event filter which is a query that specifies the type of event to be received.
+
+*filter_name* - keyword, text.text
+
+* _iptables.filter_name_ - Packet matching filter table name.
+
+*fingerprint* - keyword, text.text
+
+* _lxd_certificates.fingerprint_ - SHA256 hash of the certificate
+
+*finished_at* - keyword, text.text
+
+* _docker_containers.finished_at_ - Container finish time as string
+
+*firewall* - keyword, text.text
+
+* _windows_security_center.firewall_ - The health of the monitored Firewall (see windows_security_products)
+
+*firewall_unload* - keyword, number.long
+
+* _alf.firewall_unload_ - 1 If firewall unloading enabled else 0 (not supported on macOS 15+)
+
+*firmware_type* - keyword, text.text
+
+* _platform_info.firmware_type_ - The type of firmware (uefi, bios, iboot, openfirmware, unknown).
+
+*firmware_version* - keyword, text.text
+
+* _ibridge_info.firmware_version_ - The build version of the firmware
+
+*fix_comments* - keyword, text.text
+
+* _patches.fix_comments_ - Additional comments about the patch.
+
+*flag* - keyword, number.long
+
+* _shadow.flag_ - Reserved
+
+*flags* - keyword
+
 * _device_partitions.flags_ - Value that describes the partition (TSK_VS_PART_FLAG_ENUM)
 * _dns_cache.flags_ - DNS record flags
 * _interface_details.flags_ - Flags (netdevice) for the device
@@ -2613,7 +9135,7 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 
 *instance_identifier* - keyword, text.text
 
-* _hvci_status.instance_identifier_ - The instance ID of Device Guard.
+* _deviceguard_status.instance_identifier_ - The instance ID of Device Guard.
 
 *instance_type* - keyword, text.text
 
@@ -3106,7 +9628,7 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 
 *logging_option* - keyword, number.long
 
-* _alf.logging_option_ - Firewall logging option
+* _alf.logging_option_ - Firewall logging option (not supported on macOS 15+)
 
 *logical_processors* - keyword, number.long
 
@@ -4160,7 +10682,7 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 
 *path* - keyword, text.text
 
-* _alf_exceptions.path_ - Path to the executable that is excepted
+* _alf_exceptions.path_ - Path to the executable that is excepted. On macOS 15+ this can also be a bundle identifier
 * _apparmor_profiles.path_ - Unique, aa-status compatible, policy identifier.
 * _appcompat_shims.path_ - This is the path to the SDB database.
 * _apps.path_ - Absolute and full Name.app path
@@ -4224,7 +10746,7 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 * _quicklook_cache.path_ - Path of file
 * _registry.path_ - Full path to the value
 * _rpm_package_files.path_ - File path within the package
-* _safari_extensions.path_ - Path to extension XAR bundle
+* _safari_extensions.path_ - Path to the Info.plist describing the extension
 * _sandboxes.path_ - Path to sandbox container directory
 * _scheduled_tasks.path_ - Path to the executable to be run
 * _services.path_ - Path to Service Executable
@@ -5050,6 +11572,10 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 
 * _prefetch.run_count_ - Number of times the application has been run.
 
+*running_security_services* - keyword, text.text
+
+* _deviceguard_status.running_security_services_ - The list of running Device Guard services. Returns UNKNOWN if an error is encountered.
+
 *rw* - keyword, number.long
 
 * _docker_container_mounts.rw_ - 1 if read/write. 0 otherwise
@@ -5586,7 +12112,7 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 
 *state* - keyword
 
-* _alf_exceptions.state_ - Firewall exception state
+* _alf_exceptions.state_ - Firewall exception state. 0 if the application is configured to allow incoming connections, 2 if the application is configured to block incoming connections and 3 if the application is configuted to allow incoming connections but with additional restrictions.
 * _battery.state_ - One of the following: "AC Power" indicates the battery is connected to an external power source, "Battery Power" indicates that the battery is drawing internal power, "Off Line" indicates the battery is off-line or no longer connected
 * _chrome_extensions.state_ - 1 if this extension is enabled
 * _docker_container_processes.state_ - Process state
@@ -5961,6 +12487,10 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 * _unified_log.timestamp_ - unix timestamp associated with the entry
 * _windows_eventlog.timestamp_ - Timestamp to selectively filter the events
 
+*timestamp_double* - keyword, text.text
+
+* _unified_log.timestamp_double_ - floating point timestamp associated with the entry
+
 *timestamp_ms* - keyword, number.long
 
 * _prometheus_metrics.timestamp_ms_ - Unix timestamp of collected data in MS
@@ -6126,7 +12656,7 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 
 *umci_policy_status* - keyword, text.text
 
-* _hvci_status.umci_policy_status_ - The status of the User Mode Code Integrity security settings. Returns UNKNOWN if an error is encountered.
+* _deviceguard_status.umci_policy_status_ - The status of the User Mode Code Integrity security settings. Returns UNKNOWN if an error is encountered.
 
 *uncompressed* - keyword, number.long
 
@@ -6183,7 +12713,6 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 *update_url* - keyword, text.text
 
 * _chrome_extensions.update_url_ - Extension-supplied update URI
-* _safari_extensions.update_url_ - Extension-supplied update URI
 
 *upid* - keyword, number.long
 
@@ -6364,7 +12893,7 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 
 *vbs_status* - keyword, text.text
 
-* _hvci_status.vbs_status_ - The status of the virtualization based security settings. Returns UNKNOWN if an error is encountered.
+* _deviceguard_status.vbs_status_ - The status of the virtualization based security settings. Returns UNKNOWN if an error is encountered.
 
 *vendor* - keyword, text.text
 
@@ -6402,6 +12931,7 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 * _curl_certificate.version_ - Version Number
 * _deb_packages.version_ - Package version
 * _device_firmware.version_ - Firmware version
+* _deviceguard_status.version_ - The version number of the Device Guard build.
 * _docker_version.version_ - Docker version
 * _drivers.version_ - Driver version
 * _es_process_events.version_ - Version of EndpointSecurity event
@@ -6409,7 +12939,6 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 * _firefox_addons.version_ - Addon-supplied version string
 * _gatekeeper.version_ - Version of Gatekeeper's gke.bundle
 * _homebrew_packages.version_ - Current 'linked' version
-* _hvci_status.version_ - The version number of the Device Guard build.
 * _ie_extensions.version_ - Version of the executable
 * _intel_me_info.version_ - Intel ME version
 * _kernel_extensions.version_ - Extension version
@@ -6566,3 +13095,5 @@ For more information about osquery tables, see the https://osquery.io/schema[osq
 
 * _azure_instance_metadata.zone_ - Availability zone of the VM
 * _ycloud_instance_metadata.zone_ - Availability zone of the VM
+
+


### PR DESCRIPTION
## Summary

Update exported fields reference for osquery 5.14.1


### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



